### PR TITLE
✨feat(widgets): Navbar funnel 4 + CTA, Tier 2 도메인 disclaimer 추가

### DIFF
--- a/src/03-pages/analysis/analysis-detail-page.tsx
+++ b/src/03-pages/analysis/analysis-detail-page.tsx
@@ -111,6 +111,12 @@ export function AnalysisDetailPage() {
                   데이터가 아닌 6개월의 좁은 계절적 창에 기반합니다. 교차 참조
                   결과 1.8배가 통계적으로 근거있는 수치입니다.
                 </p>
+                <p
+                  className="font-pretendard mt-4 rounded bg-[var(--color-bg-surface)] px-4 py-2 text-xs font-medium text-[var(--color-text-accent)]"
+                  role="note"
+                >
+                  AI 분석이며 기관 검증이 아닙니다. 참고 용도로만 활용하세요.
+                </p>
               </div>
             </article>
             {/* Claim Card Tier 3: Unverifiable */}

--- a/src/04-widgets/navbar/navbar.tsx
+++ b/src/04-widgets/navbar/navbar.tsx
@@ -39,7 +39,7 @@ function Navbar() {
         </button>
         <Link
           href="/#analysis-form"
-          className="font-pretendard rounded-lg bg-[var(--color-brand-primary)] px-6 py-2 font-bold text-white transition-colors hover:bg-[var(--color-brand-secondary)]"
+          className="font-pretendard rounded-lg bg-[var(--color-brand-primary)] px-6 py-2 font-bold text-[var(--color-text-on-brand)] transition-colors hover:bg-[var(--color-brand-secondary)]"
         >
           Get Started
         </Link>

--- a/src/04-widgets/navbar/navbar.tsx
+++ b/src/04-widgets/navbar/navbar.tsx
@@ -1,5 +1,12 @@
 import Link from 'next/link';
 
+const NAV_LINKS = [
+  { label: 'Fact Check', href: '/' },
+  { label: 'Methodology', href: '/about#how-it-works' },
+  { label: 'Archive', href: '/history' },
+  { label: 'About', href: '/about' },
+] as const;
+
 function Navbar() {
   return (
     <nav className="mx-auto flex w-full max-w-7xl min-h-[var(--nav-height)] items-center justify-between border-b px-6 py-3 sm:px-8">
@@ -10,12 +17,33 @@ function Navbar() {
         CheckMate
       </Link>
 
-      <button
-        className="hidden md:block text-[var(--color-text-primary)] font-pretendard"
-        type="button"
-      >
-        로그인
-      </button>
+      <ul className="hidden md:flex items-center gap-8">
+        {NAV_LINKS.map((link) => (
+          <li key={link.href}>
+            <Link
+              href={link.href}
+              className="font-pretendard text-[var(--color-text-primary)] transition-colors hover:text-[var(--color-text-accent)]"
+            >
+              {link.label}
+            </Link>
+          </li>
+        ))}
+      </ul>
+
+      <div className="hidden md:flex items-center gap-6">
+        <button
+          className="font-pretendard text-[var(--color-text-primary)]"
+          type="button"
+        >
+          로그인
+        </button>
+        <Link
+          href="/#analysis-form"
+          className="font-pretendard rounded-lg bg-[var(--color-brand-primary)] px-6 py-2 font-bold text-white transition-colors hover:bg-[var(--color-brand-secondary)]"
+        >
+          Get Started
+        </Link>
+      </div>
 
       <button
         className="md:hidden flex flex-col gap-1"

--- a/src/07-shared/styles/tokens.css
+++ b/src/07-shared/styles/tokens.css
@@ -41,6 +41,7 @@
   --color-text-secondary: var(--color-gray-700);
   --color-text-heading: var(--color-blue-900);
   --color-text-accent: var(--color-blue-700);
+  --color-text-on-brand: #ffffff;
 
   /* 상태 */
   --color-info: var(--color-blue-500);


### PR DESCRIPTION
## 요약

5/1 회의 직전 PR #16 머지 후 후속 — Navbar funnel 차단 해소 + Tier 2 도메인 룰 위반 hotfix. 디자인 변경은 5/1 §F-7 결정 후 별도 PR로 진행 (사용자 정책 deferred).

## 변경 사항 (6건)

| # | 변경 | 위치 |
|---|------|------|
| 1 | Navbar 'Fact Check' Link | `navbar.tsx` → `/` |
| 2 | Navbar 'Methodology' Link | `navbar.tsx` → `/about#how-it-works` (5/1 후 라우트 결정 시 조정) |
| 3 | Navbar 'Archive' Link | `navbar.tsx` → `/history` |
| 4 | Navbar 'About' Link | `navbar.tsx` → `/about` |
| 5 | Navbar 'Get Started' CTA | `navbar.tsx` → `/#analysis-form` |
| 6 | Tier 2 disclaimer banner | `analysis-detail-page.tsx:114-119` |

## 근거

- **Funnel 차단** (1~5): 4/28 세션 C 평가 치명 #5 — 사용자가 SPA 페이지 이동 불가 → URL 직접 입력만 가능. Navbar 메뉴 4개 + CTA로 해소
- **도메인 룰 위반** (6): `.claude/rules/domain-logic.md` Tier 2 Disclaimer 섹션 명시. CheckMate 핵심 원칙 ("모르면 모른다") 위반 = 사용자 오인 + 법적 리스크
- 산출물: `docs/code-review-history/0428-design-eval-dev/REFACTOR-LOCATIONS.md` §1.1, §2.2

## 디자인 변경 0건 (사용자 정책 LOCK)

다음은 **본 PR에 포함되지 않음** — 5/1 §F-7 결정 후 또는 리팩토링 phase:
- M3 토큰 ~20여 종 미정의 (4페이지 silent fail)
- `rounded-full` 카드 오용 (47건)
- Display 폰트 Recipekorea 미적용
- focus-visible base 스타일
- 토큰 외 spacing 다수
- Navbar hover/focus ring 추가

## 별도 PR (정세린 영역)

- 모바일 햄버거 onClick + 모바일 drawer
- Footer 법적 link 4개 추가
- 신규 placeholder 라우트 4개 (`/terms`, `/privacy`, `/accessibility`, `/ethics`)

## 토큰만 사용 (디자인 일관성 보존)

`tokens.css` 정의된 var()만 사용:
- `--color-text-heading`, `--color-text-primary`, `--color-text-accent`
- `--color-brand-primary`, `--color-brand-secondary`
- `--color-bg-surface` (Tier 2 disclaimer banner)

## 검증

- ✅ `npm run format`
- ✅ `npm run typecheck`
- ✅ `npm run lint:fix`
- ✅ `npm run stylelint:fix`
- ✅ `npm run build`
- ⏳ CodeRabbit (자동)

## 연결 이슈

- 후속: #2 (정세린 PR #11에서 머지된 Navbar+Footer를 funnel 차원에서 보완)
- Tier 2: 4/28 세션 C 치명 #3 hotfix

## 다음 단계

1. CodeRabbit 피드백 → fix
2. 본 PR 머지 (dev)
3. 정세린 별도 PR (햄버거 onClick + Footer 법적)
4. (5/1 §7 Org rename 결정 후) dev → main create merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * AI 분석 콘텐츠임을 명확히 하는 면책 조항이 추가되었습니다
  * 데스크톱 네비게이션 바에 새로운 링크가 추가되고 구조가 개선되었습니다
  * "Get Started" 콜투액션 버튼을 통한 빠른 접근 경로가 추가되었습니다

<!-- end of auto-generated comment: release notes by coderabbit.ai -->