### PR TITLE
✨feat(governance): port LLM Behavior Gates 4-gate PR-level input contract

### DIFF
--- a/.claude/rules/llm-behavior-gates.md
+++ b/.claude/rules/llm-behavior-gates.md
@@ -1,0 +1,165 @@
+# LLM Behavior Gates — PR-level Input Contract
+
+> LLM 에이전트가 PR을 만들 때 통과해야 하는 **4 행동 게이트**.
+> Karpathy LLM 코딩 가이드라인(MIT) 4 원칙 중 행동 영역을 박제.
+> 실행/검증 계약은 [`plan-review-deep.md`](./plan-review-deep.md) Section 1의 **F1.a-d 4 subfacet**이 단일 소스 오브 트루스 — 본 rule은 **PR-level 입력 계약**(LLM 행동)만 다룸. 중복 정의 금지.
+
+## Role Separation (One-Liner)
+
+- **이 rule (Behavior Gates)** = Upstream LLM 행동 계약 — 무엇을 명시하고 무엇을 하지 말 것인가
+- **F1.a-d (plan-review-deep §1)** = Downstream 실행/검증 계약 — repro / staged / immutable / full-solution
+
+테스트 우선·CI green·재현 가능성·E2E coverage 등은 **F1로 위임**. 본 rule은 그 entry condition.
+
+### 본 rule이 다루지 않는 영역 (F1으로 위임 — 금지 예시)
+
+본 rule에 다음 항목을 추가 작성·박제 금지. F1.a-d (`plan-review-deep.md` §1)이 단일 소스 오브 트루스:
+
+- ❌ "테스트 커버리지 X% 이상" 같은 정량 기준
+- ❌ "재현 가능한 실패는 SHA 포함 명시" 같은 verification 형식
+- ❌ "E2E 테스트 1개 필수" 같은 full-solution 요구
+
+위 3종은 F1.a (Reproducible Failure), F1.c (Immutable Verification), F1.d (Full-Solution Verification) 영역. 본 rule에 적으면 cross-drift 발생 + F1 권위 약화. PR review 시 본 rule에서 발견되면 제거하고 F1로 위임할 것.
+
+## 4 Behavior Gates
+
+| # | Gate | 통과 기준 (자동 검증 가능) |
+|---|------|------------------------|
+| 1 | **Goal Defined** | Done 체크리스트 (또는 Micro-Done)가 PR 본문 `## Done` 섹션에 존재. 산출물 + 수용 테스트 명시. |
+| 2 | **Assumption Surfaced** | SAFE_OP 마커 블록에 Assumptions / Scope / Out-of-scope 3줄 명시. 기본값에서 벗어난 가정은 사용자 확인. |
+| 3 | **Surgical Diff** | 변경 라인이 모두 사용자 요청에 직접 추적. 명문 예외(보안 패치 hotfix · CI 차단 dead code) 외 인접 코드 개선 금지. |
+| 4 | **Minimum Code** | 단일 사용처 추상화·요청 외 유연성·발생 불가 시나리오 error handling 금지. "200줄 짠 게 50줄로 가능?" 통과. |
+
+## Gate 1 — Done 정의
+
+### 표준 Done
+
+다음 3가지가 PR 본문 `## Done` 섹션에 명시:
+
+- [ ] **요구사항 목록** (검증 가능한 AC): 입력 / 출력 / 에러 케이스 / 경계 조건 중 1+ 포함
+- [ ] **산출물 목록**: 생성·수정될 파일 / 엔드포인트 / CLI 명령
+- [ ] **수용 테스트**: 산출물 타입에 맞는 레벨 (unit / contract / integration / smoke / e2e) 1+
+
+### Trivial Micro-Done
+
+trivial 트리거 충족 시 1줄 형식, 사용자 확인 없이 진행:
+
+```
+요구사항: [한 줄] / 변경: [파일 경로] / 검증: 기존 테스트 통과
+```
+
+## Gate 2 — SAFE_OP 마커 블록
+
+PR 본문에 다음 블록 의무. 정규식 대신 마커 사용 — 빈줄/리스트/추가 텍스트에 견고.
+
+```
+<!-- SAFE_OP_START -->
+Assumptions: [기본값에서 벗어난 가정만, 없으면 "없음"]
+Scope: [변경할 파일/디렉토리]
+Out-of-scope: [의도적 미변경 영역]
+<!-- SAFE_OP_END -->
+```
+
+`pr-meta-check.yml` workflow가 마커 사이 필드만 파싱.
+
+### Scope 변경 절차
+
+작업 중 Scope 외 파일 수정이 필요해지면:
+
+1. 작업 중단
+2. PR 본문 SAFE_OP 블록의 Scope 라인 갱신 + 추가 코멘트:
+   `Scope 업데이트: [추가 파일] — 이유: [한 줄]`
+3. 사용자가 PR에 라벨 **`scope-ack`** 또는 코멘트 **`ACK SCOPE`** 첨부 (OR, 둘 다 OK)
+4. **외부 포크 PR**은 라벨 권한 없음 → 코멘트 `ACK SCOPE`만 허용
+5. workflow가 라벨/코멘트 존재 확인 후 재개 허용
+
+## Gate 3 — 허용 인접 변경 한도
+
+### 직접 추적의 정의
+
+해당 변경이 없으면 테스트 / 빌드 / 요구사항 / 보안 검증 / CI 중 하나가 실패.
+
+### 허용
+
+- (a) 요청한 파일
+- (b) 직접 컴파일/린트 실패를 막는 최소 라인
+- (c) 같은 파일 내 의존되는 import 추가
+- (d) **명문 예외 1**: CI 워크플로우를 차단하는 dead code 제거. PR 본문에 차단 로그 인용 필수.
+- (e) **명문 예외 2 (hotfix)**: 보안 업그레이드가 빌드 또는 CI 차단 원인일 때 (예: deps 취약점 install 실패). 동 PR 포함 허용. 범위는 의존성 1개 + 그에 따른 최소 코드 수정. PR 본문에 차단 로그(스캐너 / build) 인용 필수.
+
+### 금지
+
+- (a) 무관한 포맷 정리
+- (b) 무관한 리네이밍
+- (c) 다른 파일의 "있는 김에" 개선
+- (d) 요청 없는 dead code 삭제 (위 명문 예외 외)
+- (e) 코드 스타일 통일 (lint/formatter 외 임의 적용)
+- (f) **보안 패치 의존성 업그레이드는 본 PR 포함 금지** — 반드시 별도 PR (단 위 명문 예외 2 hotfix는 예외)
+
+## Gate 4 — Minimum Code
+
+- 요청 외 기능 추가 금지
+- 단일 사용처에 추상화 금지 (DRY는 중복 3회 이상부터 적용 — 같은 파일 내 + 함수 1개 추출만 허용)
+- 요청되지 않은 "유연성" / "설정 가능성" 금지
+- 발생 불가 시나리오 error handling 금지
+- 200줄 → 50줄 가능하면 다시 쓰기
+
+## 예외 조항 (형식적 트리거)
+
+| 컨텍스트 | 형식적 트리거 | 완화 게이트 | Done 형식 | 머지 |
+|---------|------------|-----------|---------|------|
+| **trivial** | ≤10 LOC + 새 의존성 0 + 새 파일 0 + 동작 변경 0 | Gate 1 (Micro-Done) | Micro-Done | Yes |
+| **--draft** | 사용자 메시지에 `--draft` 명시 (브랜치명·ENV 불인정) | Gate 4 | 표준 Done | No |
+| **spike** | `spike/` 디렉토리 하위 | Gate 4 | 표준 Done | No (기본 머지 금지) |
+
+### "동작 변경 0" 정의 (trivial 판정용)
+
+다음 중 **하나라도** 변경되면 ≠ 0:
+
+- 공개 인터페이스 (function signature / export / API endpoint / CLI flag)
+- UX (사용자 출력 / 에러 메시지 / 응답 형식)
+- 기존 관측성 (**기존** 로그·레벨 / 메트릭 이름 / trace span). 새 로그 추가는 변경 0.
+- 성능 특성 (asymptotic complexity / I/O 횟수)
+
+**예시**:
+- ✅ 변경 0: 주석 추가, README 오타, 미사용 변수 제거, 새 로그 라인 추가, 외부 비노출 변수 리네이밍
+- ❌ 변경 ≠ 0: 기존 로그 메시지 변경, 로그 레벨 변경, 메트릭 이름 변경, default 인자 변경, 에러 메시지 문구 변경
+
+## Failure Modes
+
+| 안티패턴 | 차단 게이트 |
+|---------|-----------|
+| "make it work" 같은 모호 목표 | Gate 1 |
+| 조용히 가정하고 진행 | Gate 2 |
+| 인접 코드 "개선" | Gate 3 |
+| 가짜 유연성·미래 추상화 | Gate 4 |
+| 의존성 과다 추가 | Gate 4 (+ F1.b downstream) |
+| 비결정적 작업 (latest 태그) | Gate 2 (+ F1.c downstream) |
+
+테스트 약화·skip / 로컬 통과만 / 재현 불가 등 **실행 결과 측 위반은 F1.a-d로 위임**. 중복 정의 금지.
+
+## Workflow 자동 강제 (`pr-meta-check.yml`)
+
+| 검사 | 정책 |
+|-----|----|
+| SAFE_OP 마커 블록 존재 | **차단** |
+| `## Done` 섹션 존재 (또는 Micro-Done) | **차단** |
+| trivial 라벨 vs diff 자동 계산 일치 | **차단** (라벨=trivial인데 LOC>10 → 차단) |
+| Scope 업데이트 코멘트 시 scope-ack 라벨 또는 ACK SCOPE 코멘트 | **차단** |
+| 수용 테스트 레벨 매트릭스 매칭 | 경고 (review 책임, 초기 2주 한정) |
+
+trigger: `pull_request` (open/edit/sync/labeled/unlabeled/reopened) + `issue_comment` (created/edited).
+권한: `contents: read` + `pull-requests: write`. **`pull_request_target` 사용 안 함** (보안 회피).
+
+## License & Attribution
+
+- Karpathy 4 원칙: [forrestchang/andrej-karpathy-skills](https://github.com/forrestchang/andrej-karpathy-skills) (MIT). 본 rule의 Gate 1/2/3/4는 그 §4/§1/§3/§2를 PR-level 행동 계약으로 박제.
+- F1 4 subfacet 위임: [`.claude/rules/plan-review-deep.md`](./plan-review-deep.md) Section 1.
+
+## See Also
+
+- [`plan-review-deep.md`](./plan-review-deep.md) §1 — F1.a-d (downstream 실행/검증)
+- `docs/architecture/decisions/ADR-006-llm-behavior-gates.md` — 본 rule 채택 근거 (6→4 축소, F1 위임 결정)
+- `.github/pull_request_template.md` — SAFE_OP 마커 + Done 섹션 임베드
+- `.github/workflows/pr-meta-check.yml` — 자동 강제 workflow
+- `.claude/skills/tdd/SKILL.md` — Pocock TDD (Gate 1·F1 entry condition)

--- a/.claude/rules/plan-review-deep.md
+++ b/.claude/rules/plan-review-deep.md
@@ -1,0 +1,164 @@
+# plan-review-deep.md — Cross-cutting governance
+
+> Source of truth for `/pf plan-review-deep` runs in this template.
+> Authored by Phase 14a (2026-05-01). **byte-identical** across `spring-template` (canonical), `python-template`, `typescript-template`.
+> Hard review limit: **300 lines**. Weighted target: **200**.
+
+## Table of Contents
+
+1. F1 4 subfacet acceptance checklist
+2. V0a / V0e / V_seed schema contract
+3. §0 schema 5 strict items
+4. Ratchet template
+5. Phase E entry rubric
+6. Phase 13c case study + external references
+7. Critical-0 convergence loop policy
+8. Phase 14b / 14c stack policy
+
+---
+
+## 1. F1 4 subfacet acceptance checklist
+
+The 4 subfacets of **F1 (Failure-First Discipline)** — top-3 abandonment-cost mindset principle from `docs/superpowers/specs/2026-04-30-programming-principles-to-templates/step4-application-matrix-detailed.md`.
+
+### F1.a Reproducible Failure
+A failure that can be reproduced deterministically by another reviewer running the same command on the same source state. No "works on my machine".
+**Verify**: capture exact command + working tree SHA + last 20 lines of stderr/stdout in the PR description.
+
+### F1.b Staged Gate
+The failure surfaces at a specific lifecycle stage (`clone` / `scaffold` / `verify` / `ci`) before downstream stages run. No silent late surface.
+**Verify**: each `validate.sh` echo header `=== F1.b ... ===` precedes the gate it is gating; `ci` step that runs `validate.sh` exits non-zero on failure.
+
+### F1.c Immutable Verification
+The verify command and its expected exit code do not depend on local mutable state (timezone, locale, date, random network state). Same input → same output.
+**Verify**: re-run the verify chain twice in a row; both must produce byte-identical stdout (modulo absolute timestamps that are masked in `awk`/`sed` filters).
+
+### F1.d Full-Solution Verification
+The verify covers the full solution path, not just a unit. A passing F1.d means the deliverable is shippable end-to-end, not just compilable.
+**Verify**: at least one happy-path E2E or integration check is part of the verify chain. Unit-only verify is insufficient.
+
+PASS counter convention: each subfacet emits a single `=== F1.x ... ===` header echo from `validate.sh`; CI counts headers via `grep -cE 'echo[[:space:]]+"=== F1\.[a-d]' validate.sh -eq 4`.
+
+---
+
+## 2. V0a / V0e / V_seed schema contract
+
+The schema below is the binding contract between this rules file and `validate.sh` of all 3 templates. Per-template variation is allowed only on the values explicitly tagged "per-template" — the surrounding code structure must remain byte-identical (cross-template structure diff is part of Tier 2 manual review).
+
+### V0a Self-monolithic guard
+
+**Purpose**: prevent `validate.sh` / `scaffold.sh` / `SETUP.md` from accreting beyond their per-template line budget without an explicit ratchet (Section 4).
+
+**Contract** (9 actual lines of bash, executed at the top of `validate.sh` after the seed echo): a `for spec in "validate.sh:N1" "scaffold.sh:N2"` loop that reads `wc -l` of each file and exits 1 with `FAIL: V0a $f has $n lines (limit $limit). 14a self-ratchet forbidden -- STOP and open a new review round.` on violation. Then a separate `wc -l < SETUP.md` block: `<= hard` exits 1, `<= soft` emits `WARN`. Per-template limits are the only values that may differ between templates.
+
+**Per-template values** (Phase 14a rev.6 R5-corrected): spring `validate:560 / scaffold:500 / SETUP 220 soft / 260 hard` ; python `validate:400 / scaffold:395 / SETUP 220 soft / 250 hard` ; typescript `validate:570 / scaffold:490 / SETUP 220 soft / 260 hard`.
+
+### V0e §0 anchor guard
+
+**Purpose**: ensure `SETUP.md` §0 contains the 5 strict items of Section 3 below — fail-closed before any V1+ verify runs.
+
+**Contract** (11 actual lines of bash): one `grep -q '^## Phase 0: System Overview'` header check + one `grep -q '^` ` `mermaid'` block check + a `for node in clone scaffold verify ci; do grep -qE "(^|[^[:alnum:]_-])${node}([^[:alnum:]_-]|$)" SETUP.md; done` 4-iteration word-boundary check + one `grep -q 'Change blast radius'` ENV column check + a `for h in 'Adding a new archetype' '...'; do grep -q "^### ${h}" SETUP.md; done` 4-iteration BRE heading check. Each missing item exits 1 with explicit `FAIL: V0e ...` message. Word-boundary for the 4 core nodes is required because `ci` is a substring of `initializr`. Phase 14a R6 ASCII canonical: heading literal contains no `§` (was `## §0 Phase 0: System Overview` before R6) so source bytes are pure ASCII -- ensures compatibility with templates that enforce ASCII-only-source guards (e.g. typescript-template V23).
+
+### V_seed Worked example seed
+
+**Purpose**: ensure the canonical entry seed file exists, has no stub phrases, and has a minimum number of lines — preventing a template from shipping a hollow archetype.
+
+**Contract** (5 actual lines of bash): one `find <archetype seed dir> -name '<canonical filename>' | sort | head -1 || true` discovery + one `[[ -n "$seed" && -f "$seed" ]]` existence check + one `grep -qE '<per-template stub regex>' "$seed" && fail` stub-phrase blocker + one `[[ $(wc -l < "$seed") -ge <N> ]]` minimum-lines check. `sort | head -1` is required for deterministic selection across filesystems. `|| true` is required to keep `pipefail` shells from misclassifying broken pipe as failure.
+
+**Per-template values**: spring `find examples/initializr-seed/src/main/java -name 'TemplateApplication.java'` + stub `(// TODO|UnsupportedOperationException|NotImplementedException|throw new RuntimeException\("not implemented"\))` + `≥3 lines` ; python `find examples/archetype-fastapi/src -name '*.py' -path '*/handlers/*'` + stub `^[[:space:]]*(pass|raise NotImplementedError\b.*|\.\.\.)[[:space:]]*$` + `≥5 lines` ; typescript `find examples/archetype-next/seed/src/app -name 'page.tsx'` + stub `(return null;|throw new Error\("Not implemented"\))` + `≥5 lines`.
+
+---
+
+## 3. §0 schema 5 strict items
+
+`SETUP.md` of every template MUST contain a `## Phase 0: System Overview` section with the following 5 items, in order. V0e (Section 2) verifies each item. Updates to `SETUP.md` Phase 0 schema MUST be paired with a V0e update in the same PR (Q5 LOCK fail-closed semantics). Phase 14a R6 ASCII canonical: heading dropped the `§` prefix (was `## §0 ...` before R6) so the heading is pure ASCII -- compatible with templates that enforce ASCII-only-source guards.
+
+(a) **Header**: a level-2 heading exactly `## Phase 0: System Overview`. No translation, no decoration, no extra spaces.
+
+(b) **Mermaid block**: an opening fence ` ```mermaid ` (BRE-anchored at start of line) followed by a Mermaid diagram before any other code block. `flowchart` or `graph` direction is up to the template.
+
+(c) **4 core nodes**: the Mermaid diagram MUST reference 4 named nodes: `clone`, `scaffold`, `verify`, `ci`. V0e checks each as a word-boundary token (substring matches like `ci` ⊂ `initializr` MUST NOT pass). The scaffold subgraph (per-template archetype list) is allowed but does not satisfy this item by itself.
+
+(d) **ENV table with `Change blast radius` column**: a Markdown table whose header row contains the literal string `Change blast radius`. The table SHOULD enumerate environment dependencies (one row per variable / file / service) and rate the blast radius of changing each.
+
+(e) **Extension Points — 4 strict English headings**: four level-3 headings, in any order, with EXACT English text: `### Adding a new archetype`, `### Adding a new verify step`, `### Adding a new env dependency`, `### Phase E (DDD/TDD) stack hook`. Translations or punctuation variants do not satisfy V0e (which uses `grep -q` BRE — literal match).
+
+---
+
+---
+
+## 4. Ratchet template
+
+A ratchet is a deliberate, documented raise of a per-template threshold (V0a `validate.sh` / `scaffold.sh` / `SETUP.md` limit). Phase 14a itself does NOT permit any same-PR ratchet — if Phase 14a code triggers V0a, the response is `STOP` and request an R5 (or later) refine round. Subsequent stack Phases (14b, 14c) MAY ratchet under the rules below.
+
+**Trigger conditions**
+- ≤10% raise vs current per-template threshold + same-PR + reviewer-approved → permitted.
+- >10% raise OR cross-template — separate PR, separate review.
+
+**Standard PR body block** — paste verbatim into the ratchet PR description:
+```
+### Ratchet — V0a `<file>` `<old>` → `<new>` (+<delta> lines, <+%>%)
+- Reason (Reality Lens): why the existing threshold is no longer adequate
+- Diff scope: what 14b / 14c addition pushed past the limit
+- Re-verify: post-merge `wc -l <file>` matches `<new>` ± 0
+- Reviewer: @<handle>
+```
+
+**Reality Lens re-verification** — every ratchet PR MUST include a `wc -l` capture in its description showing the actual line count after the new code lands. The capture command + its stdout MUST appear in the PR body before merge.
+
+---
+
+## 5. Phase E entry rubric
+
+Phase E (DDD/TDD 3-template stack — jMolecules / hexagonal / FSD-DDD) entry is gated by the 3-axis rubric below. Phase 14a-bis is the **separate** Phase that authors this rubric in detail; this Section is a normative summary only.
+
+**14a-bis 5-line meaning checklist** (Phase E hook body, one line each; the 14a-bis canonical version preserves the same 5 keywords listed below):
+1. Flexibility: small UL/BC edits (2-3 words or additions) allowed; core domain redefinition requires a new project.
+2. Universality: rule semantics MUST be expressible in terms common to all 3 stacks (Spring/Python/TS).
+3. Convention precedence: per-stack idiom > shared abstraction when they conflict — convention wins, abstractions are opt-in.
+4. Contract test specifications: every cross-stack rule has an executable contract test in each template (no English-only enforcement).
+5. Opt-in examples / docs / CI only: examples + docs are opt-in; CI gates are opt-in unless a Phase explicitly opts a rule into the V0/V_seed contract.
+
+**3-axis summary**
+- **Flexibility**: where templates may diverge (small edits, archetype-specific adapters).
+- **Universality**: what must hold across all 3 templates (V0a/V0e/V_seed schema, §0 5 strict items, F1 4 subfacets).
+- **Convention precedence**: when stack convention conflicts with shared abstraction, convention wins; the shared abstraction becomes opt-in.
+
+**Cross-drift policy** (Phase 14a R4 CX4-6, refined by 14a-bis Q1=B K3 LOCK): the 5-line meaning checklist above and the 14a-bis canonical version of the same checklist are a single source of truth. Any update to one MUST update the other with the 5 keywords (flexibility / universality / convention precedence / contract test specifications / opt-in examples) preserved in the same PR; the V_drift CI guard (validate.sh) enforces 5-keyword presence + 5-line count + negation-marker absence. If a drift surfaces (e.g., a Phase E PR changes 14a-bis but not this Section 5), the policy is to **reconcile against the spring-template `plan-review-deep.md` Section 5** as canonical and re-issue the 14a-bis update accordingly.
+
+---
+
+## 6. Phase 13c case study + external references
+
+Phase 13c (TypeScript clone+script architecture, merged `c8f4a97` on 2026-04-26 in `llm-setup-templates/typescript-template`) is the canonical worked example of the F1-discipline + scaffold/verify split + 3-tier validation that `V0a/V0e/V_seed` codify. Phase 13c plan-review-deep (Round 1-3, Critical-0 convergence) demonstrated that the Reality Lens catches `examples/.../seed/` directory drift that Contract+Completeness Lenses miss.
+
+**External references** (necessity grounded outside this Phase, per CRITIQUE.md Necessity remedy):
+
+- [Thoughtworks — TDD as a scaffold for a better product](https://www.thoughtworks.com/insights/blog/testing/tdd-as-a-scaffold-for-a-better-product): TDD as mindset/process/tool, not a single tactic.
+- [Spec-driven development — Wikipedia](https://en.wikipedia.org/wiki/Spec-driven_development): specification as executable contract; aligns with V0e/V_seed fail-closed semantics.
+- [Cookiecutter — advanced hooks](https://cookiecutter.readthedocs.io/en/stable/advanced/hooks.html): fail-closed `pre_gen_project` / `post_gen_project` pattern; precedent for V0a/V_seed exit-1-on-violation.
+
+---
+
+## 7. Critical-0 convergence loop policy
+
+A `plan-review-deep` Round converges when **(a) Critical issues = 0** + verdict ∈ {PROCEED, PROCEED-WITH-CONDITIONS}, OR **(b) Round 5 (max)** is reached and the user explicitly elects escalate option (b) "Critical을 ADR로 박제 후 PROCEED-WITH-CONDITIONS".
+
+Each round must rotate the Lens. Reference: `~/.claude/skills/project-flow/planning.md` §"Mode: plan-review-deep" — full rule including 4 Lens definitions (Contract / Completeness / Reality / Runtime Contract). New-Phase canonical cycle: Contract → Completeness → Reality → Runtime Contract → user-selected (Phase 14a R1-R5 confirmed this cycle, R5 user-selected Reality refine for baseline correction).
+
+---
+
+## 8. Phase 14b / 14c stack policy
+
+After Phase 14a (top-3 mindset principles F1 + F2 + F4 + F12 → landed across 3 templates) merges, the next stacks open in this order. Both must follow Section 4 (Ratchet template) for any same-PR threshold raise.
+
+### Phase 14b (compromise reduction + F7 3-tier expansion)
+- F5 / F8 / F10 layered additions per `step4-application-matrix-detailed.md`.
+- F7 3-tier validation expansion: `V_seed` → `V_seed-l1 / l2 / l3` per archetype maturity (typescript Tier1=F1.c / Tier2=F1.b / Tier3=F1.a precedent).
+- Same-PR ratchet allowance: ≤10% over Phase 14a-locked threshold per template (see Phase 14a PLAN.md per-template threshold rev.6 R5-corrected).
+
+### Phase 14c (deferred F11 + remainder)
+- F11 (Hidden Behavior Coverage) — deferred from 14a per Q5 LOCK.
+- Final cleanup of Phase 14a compromises (CX-10 spring V_seed `// TODO` broad pattern, R3-09 python `routers/` V_seed addition, etc.).
+
+Phase 14a-bis (3-axis Phase E entry rubric, Section 5) is a **separate Phase**, not a 14b/14c stack item.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,39 @@
+<!--
+SAFE_OP 마커 블록과 ## Done 섹션은 자동 검증 대상입니다 (`.github/workflows/pr-meta-check.yml`).
+삭제·마커 변경 시 PR 차단. 자세한 4 Behavior Gates: `.claude/rules/llm-behavior-gates.md`.
+-->
+
+<!-- SAFE_OP_START -->
+Assumptions: [기본값에서 벗어난 가정만, 없으면 "없음"]
+Scope: [변경할 파일/디렉토리]
+Out-of-scope: [의도적 미변경 영역]
+<!-- SAFE_OP_END -->
+
+## Done
+
+표준 Done (다음 3가지 모두 명시):
+
+- [ ] **요구사항 목록** (입력 / 출력 / 에러 / 경계 중 1+ 포함):
+- [ ] **산출물 목록** (파일 / 엔드포인트 / CLI 명령):
+- [ ] **수용 테스트** (산출물 타입에 맞는 레벨, 자동화 가능):
+
+또는 trivial 작업의 경우 Micro-Done (1줄):
+
+```
+요구사항: [한 줄] / 변경: [파일 경로] / 검증: 기존 테스트 통과
+```
+
+## Behavior Gates 자체 점검
+
+- [ ] Gate 1 — Goal Defined (Done 정의 위 명시)
+- [ ] Gate 2 — Assumption Surfaced (SAFE_OP 마커 블록 위 작성)
+- [ ] Gate 3 — Surgical Diff (변경 라인 모두 요청 추적, 명문 예외 외 인접 코드 개선 없음)
+- [ ] Gate 4 — Minimum Code (단일 사용처 추상화·요청 외 유연성 없음)
+
+> 실행/검증 (테스트·CI green·재현·E2E)은 F1.a-d (`.claude/rules/plan-review-deep.md` §1)로 위임. 본 점검은 PR-level 입력 계약만.
+
+---
+
 ## 관련 Issue
 closes #이슈번호
 

--- a/.github/workflows/pr-meta-check.yml
+++ b/.github/workflows/pr-meta-check.yml
@@ -1,0 +1,187 @@
+name: pr-meta-check
+
+# Validates PR-level input contract per .claude/rules/llm-behavior-gates.md (4 Behavior Gates).
+# Scope: PR body markers + Done section + scope-ack on Scope updates + trivial label vs diff.
+# Does NOT check execution/verification (F1.a-d) — that lives in validate.sh per plan-review-deep.md §1.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, labeled, unlabeled, reopened]
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check:
+    if: (github.event_name == 'pull_request' && github.event.pull_request.user.type != 'Bot') || (github.event_name == 'issue_comment' && github.event.issue.pull_request)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve PR number
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request?.number || context.payload.issue?.number;
+            if (!prNumber) core.setFailed('No PR context');
+            core.setOutput('number', prNumber);
+
+      - name: Fetch PR data
+        id: data
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        with:
+          script: |
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100
+            });
+            core.setOutput('body', pr.body || '');
+            core.setOutput('labels', JSON.stringify(pr.labels.map(l => l.name)));
+            core.setOutput('additions', pr.additions);
+            core.setOutput('deletions', pr.deletions);
+            core.setOutput('comments', JSON.stringify(comments.map(c => c.body)));
+            core.setOutput('base_sha', pr.base.sha);
+            core.setOutput('head_sha', pr.head.sha);
+
+      - name: Validate SAFE_OP marker block + Done section (Gate 1, Gate 2)
+        env:
+          BODY: ${{ steps.data.outputs.body }}
+        run: |
+          set -euo pipefail
+          missing=()
+          grep -q '<!-- SAFE_OP_START -->' <<<"$BODY" || missing+=('SAFE_OP_START marker')
+          grep -q '<!-- SAFE_OP_END -->' <<<"$BODY" || missing+=('SAFE_OP_END marker')
+          block=$(awk '/<!-- SAFE_OP_START -->/,/<!-- SAFE_OP_END -->/' <<<"$BODY" || true)
+          for field in 'Assumptions:' 'Scope:' 'Out-of-scope:'; do
+            grep -q "$field" <<<"$block" || missing+=("SAFE_OP field: $field")
+          done
+          grep -qE '^##[[:space:]]+Done' <<<"$BODY" || missing+=('## Done section')
+          if [ ${#missing[@]} -gt 0 ]; then
+            printf '::error ::Missing required: %s\n' "${missing[*]}"
+            echo 'See .claude/rules/llm-behavior-gates.md for the 4 Behavior Gates contract.'
+            exit 1
+          fi
+          echo 'PR body markers and Done section: OK'
+
+      - name: Validate Done/SAFE_OP content not template placeholder (Gate 1, Gate 2)
+        env:
+          BODY: ${{ steps.data.outputs.body }}
+        run: |
+          set -euo pipefail
+          # Done section content (between '## Done' and next '##' header)
+          done_section=$(awk '/^##[[:space:]]+Done/{flag=1;next} /^##[[:space:]]/{flag=0} flag' <<<"$BODY" || true)
+          if grep -qE '\bTBD\b|\bTODO\b' <<<"$done_section"; then
+            echo "::error ::Done section contains 'TBD' or 'TODO' - replace with actual content (Gate 1)"
+            exit 1
+          fi
+          # Template placeholder text in Done (e.g. unfilled checkboxes still showing the bracketed hint)
+          if grep -qE '\[한 줄 설명\]|\[입력 / 출력|\[파일 경로\]|\[파일 / 엔드포인트|\[산출물 타입에' <<<"$done_section"; then
+            echo "::error ::Done section contains unfilled template placeholders - replace with actual content (Gate 1)"
+            exit 1
+          fi
+          # SAFE_OP block content
+          block=$(awk '/<!-- SAFE_OP_START -->/,/<!-- SAFE_OP_END -->/' <<<"$BODY" || true)
+          if grep -qE '\[기본값에서 벗어난|\[변경할 파일|\[의도적 미변경' <<<"$block"; then
+            echo "::error ::SAFE_OP block contains unfilled template placeholders - replace with actual content (Gate 2)"
+            exit 1
+          fi
+          echo 'Done/SAFE_OP placeholder check: OK'
+
+      - name: Validate F1 anchor exists in plan-review-deep.md (cross-drift guard)
+        run: |
+          set -euo pipefail
+          # llm-behavior-gates.md delegates execution/verification to F1.a-d in plan-review-deep.md Section 1.
+          # If the anchor breaks (file rename, section header change, keyword removal),
+          # the cross-reference becomes silently broken.
+          if [ ! -f .claude/rules/plan-review-deep.md ]; then
+            echo "::error ::plan-review-deep.md missing - F1 delegation broken"
+            exit 1
+          fi
+          if ! grep -qE '^## 1\.' .claude/rules/plan-review-deep.md; then
+            echo "::error ::Section 1 header anchor missing in plan-review-deep.md - F1 delegation broken"
+            exit 1
+          fi
+          for sub in 'F1\.a' 'F1\.b' 'F1\.c' 'F1\.d'; do
+            grep -qE "$sub" .claude/rules/plan-review-deep.md \
+              || { echo "::error ::$sub keyword missing from plan-review-deep.md - F1 contract broken"; exit 1; }
+          done
+          echo 'F1 anchor + 4 subfacet keywords verified'
+
+      - name: Detect new files + dependency manifest changes
+        id: diff
+        env:
+          BASE_SHA: ${{ steps.data.outputs.base_sha }}
+          HEAD_SHA: ${{ steps.data.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          new_files=$(git diff --name-only --diff-filter=A "$BASE_SHA".."$HEAD_SHA" | wc -l)
+          manifest_changed=0
+          for m in build.gradle build.gradle.kts pom.xml package.json package-lock.json yarn.lock pnpm-lock.yaml pyproject.toml poetry.lock requirements.txt Pipfile.lock; do
+            git diff --name-only "$BASE_SHA".."$HEAD_SHA" | grep -qx "$m" && manifest_changed=1 || true
+          done
+          echo "new_files=$new_files" >> "$GITHUB_OUTPUT"
+          echo "manifest_changed=$manifest_changed" >> "$GITHUB_OUTPUT"
+
+      - name: Validate trivial label vs auto-conditions
+        env:
+          LABELS: ${{ steps.data.outputs.labels }}
+          ADDITIONS: ${{ steps.data.outputs.additions }}
+          DELETIONS: ${{ steps.data.outputs.deletions }}
+          NEW_FILES: ${{ steps.diff.outputs.new_files }}
+          MANIFEST_CHANGED: ${{ steps.diff.outputs.manifest_changed }}
+        run: |
+          set -euo pipefail
+          loc_total=$(( ADDITIONS + DELETIONS ))
+          has_trivial=$(jq -r '. | index("trivial") // empty' <<<"$LABELS")
+          conditions_met=true
+          [ "$loc_total" -le 10 ] || conditions_met=false
+          [ "$NEW_FILES" -eq 0 ] || conditions_met=false
+          [ "$MANIFEST_CHANGED" -eq 0 ] || conditions_met=false
+          if [ -n "$has_trivial" ] && [ "$conditions_met" = false ]; then
+            echo "::error ::Label 'trivial' set but conditions unmet (LOC=$loc_total, new_files=$NEW_FILES, manifest=$MANIFEST_CHANGED)"
+            exit 1
+          fi
+          if [ -z "$has_trivial" ] && [ "$conditions_met" = true ]; then
+            echo "::warning ::Trivial conditions met but 'trivial' label not set. Consider adding the label."
+          fi
+          echo 'Trivial label check: OK'
+
+      - name: Validate Scope update -> scope-ack required
+        env:
+          LABELS: ${{ steps.data.outputs.labels }}
+          COMMENTS: ${{ steps.data.outputs.comments }}
+        run: |
+          set -euo pipefail
+          scope_update=$(jq -r '.[]' <<<"$COMMENTS" | grep -c 'Scope 업데이트:' || true)
+          if [ "$scope_update" -gt 0 ]; then
+            has_label=$(jq -r '. | index("scope-ack") // empty' <<<"$LABELS")
+            has_comment=$(jq -r '.[]' <<<"$COMMENTS" | grep -c 'ACK SCOPE' || true)
+            if [ -z "$has_label" ] && [ "$has_comment" -eq 0 ]; then
+              echo "::error ::Scope update comment present but no 'scope-ack' label or 'ACK SCOPE' comment found"
+              exit 1
+            fi
+          fi
+          echo 'Scope-ack check: OK'
+
+      - name: Summary
+        run: |
+          echo 'PR meta contract checks passed (4 Behavior Gates input form).'
+          echo 'Execution/verification (F1.a-d) is enforced separately by validate.sh / CI workflow.'
+          echo 'See .claude/rules/llm-behavior-gates.md and ADR-006-llm-behavior-gates.md.'

--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,8 @@ lint.json
 .vercel
 
 # Local planning
-.claude/
+.claude/*
+!.claude/rules/
 .plans/
 context/
 


### PR DESCRIPTION
<!--
SAFE_OP 마커 블록과 ## Done 섹션은 본 PR이 박제하는 자동 검증 대상입니다.
이 PR 자체에도 SAFE_OP + Done 형식을 적용 (workflow가 PR head SHA의 yml로 동작하므로 self-validating).
-->

<!-- SAFE_OP_START -->
Assumptions: TruthScope에는 `.claude/rules/`, `docs/architecture/decisions/` infrastructure 미존재 — lite 박제로 4 gates rule + F1 위임 source(plan-review-deep.md) + workflow + PR template 4종만 포팅
Scope: .claude/rules/{llm-behavior-gates.md,plan-review-deep.md}, .github/workflows/pr-meta-check.yml, .github/PULL_REQUEST_TEMPLATE.md, .gitignore (.claude/rules/ allow)
Out-of-scope: ADR-XXX-llm-behavior-gates.md (TruthScope에 ADR 인프라 없음 — 별도 PR), `.github/workflows/ci.yml` 통합, branch protection contexts 갱신
<!-- SAFE_OP_END -->

## Done

- [x] **요구사항**: PR-level 입력 계약(SAFE_OP 마커 + Done 섹션 + scope-ack + trivial 매트릭스) workflow 강제. 머지 후 새 PR 생성 시 본 4-Gate 검증 트리거.
- [x] **산출물**:
  - `.claude/rules/llm-behavior-gates.md` (165 lines, 4 gates 본문)
  - `.claude/rules/plan-review-deep.md` (164 lines, F1 4 subfacet — workflow F1 anchor guard가 require)
  - `.github/workflows/pr-meta-check.yml` (187 lines, **bot author skip 포함** — spring-template P0 fix `de12b65d` 통합)
  - `.github/PULL_REQUEST_TEMPLATE.md` (36 lines prepended — SAFE_OP + Done + Behavior Gates 점검; 기존 팀 체크리스트는 보존)
  - `.gitignore` 1줄 정정 (`.claude/*` + `!.claude/rules/`로 rules만 허용)
- [x] **수용 테스트**: 본 PR이 자기 자신의 첫 검증 대상. workflow run 통과 시 Gate 1/2/3/4 입력 계약 강제 동작 확인.

## Behavior Gates 자체 점검

- [x] Gate 1 — Goal Defined (위 Done 명시)
- [x] Gate 2 — Assumption Surfaced (SAFE_OP 마커 블록 위 작성)
- [x] Gate 3 — Surgical Diff (5 파일 변경 모두 Behavior Gates 박제 직접 추적; .gitignore는 .claude/rules/ 추적을 막던 차단 제거 — 본 PR 직접 의존)
- [x] Gate 4 — Minimum Code (lite scope: ADR/CodeRabbit/CI 통합 모두 별도 PR로 분리)

## 핵심 설계 결정

### 1. Lite 박제 — ADR 제외
spring-template은 ADR-006-llm-behavior-gates.md로 채택 근거를 박제하지만 TruthScope BE/FE에는 `docs/architecture/decisions/` 인프라 자체가 없음. ADR 인프라 신설은 본 PR scope를 2배로 키움 — 별도 PR로 분리.

`llm-behavior-gates.md`의 `See Also` 섹션이 `docs/architecture/decisions/ADR-006-llm-behavior-gates.md`를 참조하는 부분은 dangling link로 남음. 머지 직후 follow-up PR에서 ADR 인프라 신설 + ADR 박제할 것.

### 2. Bot author skip 사전 통합
spring-template `fix/pr-meta-bot-skip` PR (#29)이 머지 대기 중. 본 PR의 workflow는 그 fix가 통합된 버전(`de12b65d`)을 사용해서 dependabot/renovate PR 자동 차단을 회피. 즉 머지 직후부터 dependabot도 OK.

### 3. Pre-existing 팀 체크리스트 보존 (Gate 3 surgical)
기존 PR template의 "관련 Issue / 변경 사항 / 체크리스트 / 스크린샷" 4 섹션은 그대로 유지. SAFE_OP block + Done section + Behavior Gates 점검을 위에 prepend.

## 후속 작업 (별도 PR)

1. ADR 인프라 신설 + ADR-001-llm-behavior-gates 박제
2. CodeRabbit `.coderabbit.yaml`에서 본 rule 인지 (선택)
3. branch protection contexts에 `pr-meta-check / check` job 추가 (현재는 advisory)
