### PR TITLE
✨feat(result-card): verdict → TruthLabel 5 + ClaimScoreStatus 3 정본 정정 (ADR-014 + Phase 55)

### DIFF
--- a/src/04-widgets/result-card/index.ts
+++ b/src/04-widgets/result-card/index.ts
@@ -4,5 +4,6 @@ export type {
   FactCheckSnapshot,
   ContextSnapshot,
   RelatedArticleRef,
-  Verdict,
+  TruthLabel,
+  ClaimScoreStatus,
 } from './model/types';

--- a/src/04-widgets/result-card/model/types.ts
+++ b/src/04-widgets/result-card/model/types.ts
@@ -1,9 +1,33 @@
 /**
- * S2-08 skeleton-only types. Sprint 4에서 실 데이터 (BE response) 결합 시
- * 06-entities/analysis-result/ aggregate에 의해 대체될 가능성 있음.
+ * ResultCard 도메인 타입. Phase 55 D12 + ADR-014 정합 (5/22 LOCK).
+ *
+ * - TruthLabel 5종: claim score 산출 가능 시 도출 (Phase 55 deriveTruthLabel).
+ * - ClaimScoreStatus 3종: claim score 산출 불가 시 별도 상태 (verdict 5종 중 비판정).
+ *
+ * BE 매핑: truthscope-web-backend/core/.../scoring/{TruthLabel,ClaimScoreStatus}.java
+ * ADR-014 §5: FE에서 신규 enum 생성 금지, BE 도출값 직접 매핑.
  */
 
-export type Verdict = 'TRUE' | 'PARTIAL' | 'FALSE' | 'UNVERIFIED' | 'PENDING';
+/**
+ * 진실성 5종 (claim score 0..100 밴딩에서 도출).
+ * 정세린 딥리서치 + Sprint 2 Q1 정합 + codex thread 019e4af1 2라운드 + 사용자 승인.
+ */
+export type TruthLabel =
+  | 'FACT'
+  | 'MOSTLY_FACT'
+  | 'PARTLY_FACT'
+  | 'MOSTLY_NOT_FACT'
+  | 'NOT_FACT';
+
+/**
+ * 비판정 3종 (claim score 산출 불가, NULL score).
+ * verdict 5종(SUPPORTED/CONTRADICTED/INSUFFICIENT/TIME_SENSITIVE/OUT_OF_SCOPE) 중
+ * 비판정 영역. SUPPORTED/CONTRADICTED는 TruthLabel로 도출됨.
+ */
+export type ClaimScoreStatus =
+  | 'INSUFFICIENT'
+  | 'TIME_SENSITIVE'
+  | 'OUT_OF_SCOPE';
 
 export interface RelatedArticleRef {
   id: string;
@@ -12,8 +36,11 @@ export interface RelatedArticleRef {
 }
 
 export interface FactCheckSnapshot {
-  verdict?: Verdict;
-  /** 0-100. 모델 자신감 등 BE 정의 따라감 (Sprint 4 결정). */
+  /** claim score 산출 가능 시 도출 라벨 (TruthLabel 5종). status와 mutually exclusive. */
+  truthLabel?: TruthLabel;
+  /** claim score 산출 불가 시 상태 (비판정 3종). truthLabel과 mutually exclusive. */
+  status?: ClaimScoreStatus;
+  /** 0-100. TruthLabel일 때만 의미. status일 때 NULL ("모르면 모른다" 원칙). */
   confidence?: number;
   claim?: string;
   evidence?: string[];

--- a/src/04-widgets/result-card/ui/fact-check-section.tsx
+++ b/src/04-widgets/result-card/ui/fact-check-section.tsx
@@ -3,31 +3,49 @@
 import { useId } from 'react';
 import { cn } from '@/07-shared/lib/cn';
 import type {
+  ClaimScoreStatus,
   FactCheckSnapshot,
-  Verdict,
+  TruthLabel,
 } from '@04-widgets/result-card/model/types';
 
 interface VerdictDisplay {
   label: string;
   icon: string;
-  tone: 'success' | 'error' | 'info' | 'subtle' | 'neutral';
+  tone:
+    | 'success'
+    | 'success-soft'
+    | 'mixed'
+    | 'error-soft'
+    | 'error'
+    | 'info'
+    | 'neutral';
 }
 
-const VERDICT_DISPLAY: Record<Verdict, VerdictDisplay> = {
-  TRUE: { label: '사실', icon: '✓', tone: 'success' },
-  PARTIAL: { label: '부분 사실', icon: '◑', tone: 'subtle' },
-  FALSE: { label: '거짓', icon: '✕', tone: 'error' },
-  UNVERIFIED: { label: '검증 불가', icon: '?', tone: 'neutral' },
-  PENDING: { label: '검증 중', icon: '⋯', tone: 'info' },
+const TRUTH_LABEL_DISPLAY: Record<TruthLabel, VerdictDisplay> = {
+  FACT: { label: '사실', icon: '✓', tone: 'success' },
+  MOSTLY_FACT: { label: '대체로 사실', icon: '✓', tone: 'success-soft' },
+  PARTLY_FACT: { label: '일부 사실', icon: '◑', tone: 'mixed' },
+  MOSTLY_NOT_FACT: { label: '대체로 사실 아님', icon: '✕', tone: 'error-soft' },
+  NOT_FACT: { label: '사실 아님', icon: '✕', tone: 'error' },
+};
+
+const STATUS_DISPLAY: Record<ClaimScoreStatus, VerdictDisplay> = {
+  INSUFFICIENT: { label: '근거 부족', icon: '?', tone: 'neutral' },
+  TIME_SENSITIVE: { label: '시점 의존', icon: '⋯', tone: 'info' },
+  OUT_OF_SCOPE: { label: '검증 범위 밖', icon: '—', tone: 'neutral' },
 };
 
 const TONE_CLASS: Record<VerdictDisplay['tone'], string> = {
   success:
     'bg-[var(--color-success-subtle)] text-[var(--color-success-strong)] ring-[var(--color-success-strong)]/30',
+  'success-soft':
+    'bg-[var(--color-success-subtle)] text-[var(--color-success-strong)]/80 ring-[var(--color-success-strong)]/20',
+  mixed: 'bg-brand-subtle text-brand-primary ring-brand-primary/30',
+  'error-soft':
+    'bg-[var(--color-error-subtle)] text-[var(--color-error)]/80 ring-[var(--color-error)]/20',
   error:
     'bg-[var(--color-error-subtle)] text-[var(--color-error)] ring-[var(--color-error)]/30',
   info: 'bg-[var(--color-blue-50)] text-[var(--color-info)] ring-[var(--color-info)]/30',
-  subtle: 'bg-brand-subtle text-brand-primary ring-brand-primary/30',
   neutral:
     'bg-[var(--color-bg-surface-sunken)] text-[var(--color-text-secondary)] ring-[var(--color-border-subtle)]',
 };
@@ -39,8 +57,13 @@ interface Props {
 
 export function FactCheckSection({ snapshot, className }: Props) {
   const titleId = useId();
-  const verdict = snapshot?.verdict;
-  const display = verdict ? VERDICT_DISPLAY[verdict] : null;
+  const display = snapshot?.truthLabel
+    ? TRUTH_LABEL_DISPLAY[snapshot.truthLabel]
+    : snapshot?.status
+      ? STATUS_DISPLAY[snapshot.status]
+      : null;
+  const showConfidence =
+    typeof snapshot?.confidence === 'number' && Boolean(snapshot?.truthLabel);
 
   return (
     <section
@@ -95,12 +118,12 @@ export function FactCheckSection({ snapshot, className }: Props) {
           <p className="text-xs uppercase tracking-wide text-[var(--color-text-secondary)]">
             근거
           </p>
-          {typeof snapshot?.confidence === 'number' && (
+          {showConfidence && (
             <p
-              aria-label={`신뢰도 ${snapshot.confidence}퍼센트`}
+              aria-label={`신뢰도 ${snapshot?.confidence}퍼센트`}
               className="text-xs text-[var(--color-text-secondary)] tabular-nums"
             >
-              신뢰도 {snapshot.confidence}%
+              신뢰도 {snapshot?.confidence}%
             </p>
           )}
         </div>

--- a/src/04-widgets/result-card/ui/result-card.stories.tsx
+++ b/src/04-widgets/result-card/ui/result-card.stories.tsx
@@ -19,11 +19,11 @@ export const Skeleton: Story = {
   },
 };
 
-export const True: Story = {
+export const Fact: Story = {
   args: {
     snapshot: {
       factCheck: {
-        verdict: 'TRUE',
+        truthLabel: 'FACT',
         confidence: 92,
         claim: '공식 통계 기준 전년 대비 수출액이 12.4% 증가했다.',
         evidence: [
@@ -44,11 +44,11 @@ export const True: Story = {
   },
 };
 
-export const Partial: Story = {
+export const MostlyFact: Story = {
   args: {
     snapshot: {
       factCheck: {
-        verdict: 'PARTIAL',
+        truthLabel: 'MOSTLY_FACT',
         confidence: 76,
         claim: '전문가 다수는 해당 정책의 단기 효과를 긍정적으로 봤다.',
         evidence: ['보고서 방향은 일치하지만 범위가 일부 축약됐습니다.'],
@@ -61,11 +61,48 @@ export const Partial: Story = {
   },
 };
 
-export const False: Story = {
+export const PartlyFact: Story = {
   args: {
     snapshot: {
       factCheck: {
-        verdict: 'FALSE',
+        truthLabel: 'PARTLY_FACT',
+        confidence: 54,
+        claim: '지원금 증가가 청년 고용률 회복의 주된 원인이다.',
+        evidence: ['수치 방향은 맞지만 인과 설명은 확인되지 않았습니다.'],
+      },
+      context: {
+        summary: '다른 경기 변수와 정책 시차가 분리되지 않았습니다.',
+        sourceCount: 2,
+      },
+    },
+  },
+};
+
+export const MostlyNotFact: Story = {
+  args: {
+    snapshot: {
+      factCheck: {
+        truthLabel: 'MOSTLY_NOT_FACT',
+        confidence: 31,
+        claim: '해당 법안은 이미 모든 절차를 통과해 시행 중이다.',
+        evidence: [
+          '상임위 계류 상태로, 시행 중이라는 표현은 부정확합니다.',
+          '일부 조항은 별도 시행령으로 검토 중입니다.',
+        ],
+      },
+      context: {
+        summary: '법안은 입법 절차의 일부만 통과했습니다.',
+        sourceCount: 3,
+      },
+    },
+  },
+};
+
+export const NotFact: Story = {
+  args: {
+    snapshot: {
+      factCheck: {
+        truthLabel: 'NOT_FACT',
         confidence: 88,
         claim: '지난해 같은 지역의 사고 건수는 0건이었다.',
         evidence: [
@@ -81,31 +118,51 @@ export const False: Story = {
   },
 };
 
-export const Unverified: Story = {
+export const Insufficient: Story = {
   args: {
     snapshot: {
       factCheck: {
-        verdict: 'UNVERIFIED',
-        claim: '지원금 증가가 청년 고용률 회복의 주된 원인이다.',
-        evidence: ['다른 경기 변수와 정책 시차가 분리되지 않았습니다.'],
+        status: 'INSUFFICIENT',
+        claim: '해당 사건의 책임자는 A 회사이다.',
+        evidence: ['확인 가능한 출처가 1건뿐이며 교차 검증이 어렵습니다.'],
       },
       context: {
-        summary: '인과 관계 확인을 위해 추가 자료가 필요합니다.',
-        sourceCount: 0,
+        summary: '추가 1차 출처가 확인되면 재평가 가능합니다.',
+        sourceCount: 1,
       },
     },
   },
 };
 
-export const Pending: Story = {
+export const TimeSensitive: Story = {
   args: {
     snapshot: {
       factCheck: {
-        verdict: 'PENDING',
-        claim: '검증 진행 중입니다.',
+        status: 'TIME_SENSITIVE',
+        claim: '오늘 기준 환율은 1,380원이다.',
+        evidence: [
+          '실시간 환율 변동성이 커 시점 명시 없이는 사실성 평가가 어렵습니다.',
+        ],
       },
       context: {
-        summary: 'BE 응답 대기 중',
+        summary: '시점 정보가 명확해지면 재검증 가능합니다.',
+        sourceCount: 1,
+      },
+    },
+  },
+};
+
+export const OutOfScope: Story = {
+  args: {
+    snapshot: {
+      factCheck: {
+        status: 'OUT_OF_SCOPE',
+        claim: '이 정책은 윤리적으로 옳다.',
+        evidence: ['가치 판단 주장은 사실 검증 범위 밖입니다.'],
+      },
+      context: {
+        summary: 'TruthScope는 검증 가능한 사실 단위만 다룹니다.',
+        sourceCount: 0,
       },
     },
   },

--- a/src/app/analysis/[id]/page.tsx
+++ b/src/app/analysis/[id]/page.tsx
@@ -22,13 +22,13 @@ export default function AnalysisDetailPage() {
     </Link>
   );
 
-  // Sprint 4 BE 매핑 전 임시 ResultCardSnapshot. Task #10 후속 PR에서 verdict 5종 정본
-  // (FACT/MOSTLY_FACT/PARTLY_FACT/MOSTLY_NOT_FACT/NOT_FACT + 비판정 3종) + Spring Boot
-  // AnalysisSession.completeCascade 응답 매핑으로 교체된다.
+  // Sprint 4 BE 매핑 전 임시 snapshot. truthLabel/status 둘 다 undefined로 두면
+  // SkeletonPill이 자동 표시되어 "분석 대기 중" 상태가 시각으로 전달된다.
+  // BE Spring Boot AnalysisSession.completeCascade 응답이 들어오면 truthLabel(5종)
+  // 또는 status(3종)와 confidence/evidence가 채워지는 매핑으로 교체된다.
   const cardSnapshot: ResultCardSnapshot | undefined = snapshot
     ? {
         factCheck: {
-          verdict: 'PENDING',
           claim: snapshot.title,
         },
         context: {


### PR DESCRIPTION
<!-- SAFE_OP_START -->
Assumptions: ADR-014(verification_results.verdict 5종) + Phase 55 D12(deriveTruthLabel 5종) + ClaimScoreStatus 비판정 3종이 정본. FE는 BE 도출값 직접 매핑(ADR-014 §5).
Scope: src/04-widgets/result-card/{model,ui,index}, src/app/analysis/[id]/page.tsx
Out-of-scope: BE Spring Boot AnalysisSession.completeCascade 응답 매핑 (Sprint 4 별 트랙). v1.5 설계서 업데이트 (별 트랙, git 미푸시).
<!-- SAFE_OP_END -->

## Done

### 요구사항

- [✅] PR #38의 TRUE/PARTIAL/FALSE/UNVERIFIED/PENDING 5종 verdict → Phase 55 TruthLabel 5종 + ClaimScoreStatus 비판정 3종으로 정정
- [✅] truthLabel과 status mutually exclusive (한 claim은 둘 중 하나만 보유)
- [✅] confidence는 truthLabel일 때만 의미 (status일 때 NULL — "모르면 모른다" 원칙)
- [✅] 한글 라벨 정합 (사실/대체로 사실/일부 사실/대체로 사실 아님/사실 아님 + 근거 부족/시점 의존/검증 범위 밖)
- [✅] tone 7종 재설계 (success/success-soft/mixed/error-soft/error/info/neutral)
- [✅] BE 도출값 직접 매핑 (ADR-014 §5 정합, FE 신규 enum 생성 금지)
- [✅] Skeleton 상태 자동 처리 (PENDING UI 임시 상태 제거, undefined 시 SkeletonPill)

### 산출물

- `src/04-widgets/result-card/model/types.ts`: Verdict 폐기, TruthLabel + ClaimScoreStatus 신규
- `src/04-widgets/result-card/ui/fact-check-section.tsx`: TRUTH_LABEL_DISPLAY(5) + STATUS_DISPLAY(3) + tone 7종 분리
- `src/04-widgets/result-card/index.ts`: barrel export 정정
- `src/app/analysis/[id]/page.tsx`: PENDING → undefined (SkeletonPill 자동 표시)
- `src/04-widgets/result-card/ui/result-card.stories.tsx`: 6 → 9 stories

### 수용 테스트

- [✅] `npm run format` PASS
- [✅] `npm run typecheck` PASS
- [✅] `npm run lint` PASS
- [✅] `npm run stylelint` PASS
- [✅] `npm run build` PASS
- [✅] `npm run build-storybook` PASS (TruthLabel 5 + ClaimScoreStatus 3 = 9 stories)

### BE 매핑 (Sprint 4 별 트랙)

본 PR은 FE 표시 라벨 정합만. BE Spring Boot 매핑은 후속:
- `truthscope-web-backend/core/.../scoring/TruthLabel.java` → FE TruthLabel
- `truthscope-web-backend/core/.../scoring/ClaimScoreStatus.java` → FE ClaimScoreStatus
- `AnalysisSession.completeCascade` 응답 → ResultCardSnapshot 매핑

### 디자인 시스템 준수

- Phase 22 v2 tokens.css source-of-truth 유지 (신규 토큰 0건)
- tone 7종 모두 기존 semantic token 활용 (success/error/info/brand-subtle/border-subtle 조합)
- WCAG 1.4.1 4채널 (모양 + 아이콘 + 색 + 텍스트) 유지

### 관련 ADR

- ADR-014 (verification_results.label → Verdict enum 마이그레이션, 2026-05-22 Accepted)
- Phase 55 D12 (TruthLabel 5종 도출 + ClaimScoreStatus 3종 분리, 5/22 LOCK)

Co-authored-by: KWONSEOK02 <gwonseok02@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 팩트체크 결과 표시 시스템을 더욱 세분화하여 개선했습니다. 기존의 단일 판정 방식에서 사실 여부(5단계)와 검증 상태(3가지)를 구분하여 더 명확한 정보 전달이 가능해졌습니다.
  * 팩트체크 결과의 시각적 표현과 신뢰도 표시 로직을 업데이트했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/truthscope-smu/truthscope-web-frontend/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->