### PR TITLE
✨feat(badge): FreshnessBadge widget 5-bucket 노후도 표시 (FE #48)

### DIFF
--- a/.claude/rules/design.md
+++ b/.claude/rules/design.md
@@ -36,6 +36,7 @@ padding: var(--spacing-10);
 - Primary action / confidence signal은 `brand-primary`를 기본값으로 한다.
 - 두 번째 primary accent 도입 금지 — 회귀 방지 룰.
 - 상태색(error / success / info)은 semantic token을 유지한다 (별도 신호 채널).
+- 노후도 신호 채널: aging(orange) / warning(amber) 상태 토큰 추가 (Phase 62 FreshnessBadge). 텍스트는 어두운 공통색(text-primary)으로 두고, 상태색은 아이콘 색과 좌측 border accent 및 옅은 배경 tint에만 적용한다. 색 단독 의존 금지(WCAG 1.4.1) — 아이콘 모양과 라벨 문구로도 구별한다.
 
 **채택 근거 — 미적 취향 아닌 3 기능적 사유**:
 1. **WCAG 2.2 AA 대비 보장** (§1.4.3 Contrast Minimum) — `brand-primary` blue-900은 white/parchment surface 모두에서 텍스트 4.5:1 확보 가능. 단일 색이라 모든 surface 조합 검증이 단순화됨.

--- a/src/04-widgets/freshness-badge/index.ts
+++ b/src/04-widgets/freshness-badge/index.ts
@@ -1,0 +1,2 @@
+export { FreshnessBadge } from './ui/freshness-badge';
+export type { StalenessHint, FreshnessBadgeProps } from './model/types';

--- a/src/04-widgets/freshness-badge/lib/badge-config.ts
+++ b/src/04-widgets/freshness-badge/lib/badge-config.ts
@@ -1,0 +1,41 @@
+import type { StalenessHint } from '@04-widgets/freshness-badge/model/types';
+
+export interface BadgeVisual {
+  label: string;
+  icon: string;
+  className: string;
+  ariaPrefix: string;
+}
+
+export const BADGE_CONFIG: Record<StalenessHint, BadgeVisual> = {
+  fresh: {
+    label: '최신',
+    icon: '✓',
+    className: 'badge-fresh',
+    ariaPrefix: '검증 최신',
+  },
+  stable: {
+    label: '안정',
+    icon: '◐',
+    className: 'badge-stable',
+    ariaPrefix: '검증 안정',
+  },
+  aging: {
+    label: '노후화',
+    icon: '◑',
+    className: 'badge-aging',
+    ariaPrefix: '검증 노후화',
+  },
+  stale: {
+    label: '노후',
+    icon: '◓',
+    className: 'badge-stale',
+    ariaPrefix: '검증 노후',
+  },
+  expired: {
+    label: '만료',
+    icon: '⚠',
+    className: 'badge-expired',
+    ariaPrefix: '검증 만료',
+  },
+};

--- a/src/04-widgets/freshness-badge/lib/compute-staleness-hint.test.ts
+++ b/src/04-widgets/freshness-badge/lib/compute-staleness-hint.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { computeStalenessHint } from '@04-widgets/freshness-badge/lib/compute-staleness-hint';
+
+const ONE_HOUR = 60 * 60 * 1000;
+const ONE_DAY = 24 * ONE_HOUR;
+const THREE_DAYS = 3 * ONE_DAY;
+const SEVEN_DAYS = 7 * ONE_DAY;
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('computeStalenessHint — 5 bucket representative values', () => {
+  it('30min -> fresh', () => {
+    const now = 1_000_000_000_000;
+    expect(computeStalenessHint(now - 30 * 60 * 1000, now)).toBe('fresh');
+  });
+
+  it('12h -> stable', () => {
+    const now = 1_000_000_000_000;
+    expect(computeStalenessHint(now - 12 * ONE_HOUR, now)).toBe('stable');
+  });
+
+  it('2d -> aging', () => {
+    const now = 1_000_000_000_000;
+    expect(computeStalenessHint(now - 2 * ONE_DAY, now)).toBe('aging');
+  });
+
+  it('5d -> stale', () => {
+    const now = 1_000_000_000_000;
+    expect(computeStalenessHint(now - 5 * ONE_DAY, now)).toBe('stale');
+  });
+
+  it('12d -> expired', () => {
+    const now = 1_000_000_000_000;
+    expect(computeStalenessHint(now - 12 * ONE_DAY, now)).toBe('expired');
+  });
+});
+
+describe('computeStalenessHint — boundary values', () => {
+  it('diff=0 -> fresh', () => {
+    const now = 1_000_000_000_000;
+    expect(computeStalenessHint(now, now)).toBe('fresh');
+  });
+
+  it('diff=1h exactly -> fresh', () => {
+    const now = 1_000_000_000_000;
+    expect(computeStalenessHint(now - ONE_HOUR, now)).toBe('fresh');
+  });
+
+  it('diff=1h+1ms -> stable', () => {
+    const now = 1_000_000_000_000;
+    expect(computeStalenessHint(now - ONE_HOUR - 1, now)).toBe('stable');
+  });
+
+  it('diff=24h exactly -> stable', () => {
+    const now = 1_000_000_000_000;
+    expect(computeStalenessHint(now - ONE_DAY, now)).toBe('stable');
+  });
+
+  it('diff=24h+1ms -> aging', () => {
+    const now = 1_000_000_000_000;
+    expect(computeStalenessHint(now - ONE_DAY - 1, now)).toBe('aging');
+  });
+
+  it('diff=3d exactly -> aging', () => {
+    const now = 1_000_000_000_000;
+    expect(computeStalenessHint(now - THREE_DAYS, now)).toBe('aging');
+  });
+
+  it('diff=3d+1ms -> stale', () => {
+    const now = 1_000_000_000_000;
+    expect(computeStalenessHint(now - THREE_DAYS - 1, now)).toBe('stale');
+  });
+
+  it('diff=7d exactly -> stale', () => {
+    const now = 1_000_000_000_000;
+    expect(computeStalenessHint(now - SEVEN_DAYS, now)).toBe('stale');
+  });
+
+  it('diff=7d+1ms -> expired', () => {
+    const now = 1_000_000_000_000;
+    expect(computeStalenessHint(now - SEVEN_DAYS - 1, now)).toBe('expired');
+  });
+});
+
+describe('computeStalenessHint — edge cases', () => {
+  it('future timestamp (negative diff) -> fresh (clamped)', () => {
+    const now = 1_000_000_000_000;
+    // createdAtMs is in the future relative to nowMs
+    expect(computeStalenessHint(now + 5 * ONE_DAY, now)).toBe('fresh');
+  });
+
+  it('NaN createdAtMs -> expired', () => {
+    expect(computeStalenessHint(NaN, 1_000_000_000_000)).toBe('expired');
+  });
+
+  it('Infinity createdAtMs -> expired', () => {
+    expect(computeStalenessHint(Infinity, 1_000_000_000_000)).toBe('expired');
+  });
+
+  it('uses Date.now() as default nowMs via fake timers', () => {
+    const fixedMs = 1_000_000_000_000;
+    vi.useFakeTimers();
+    vi.setSystemTime(fixedMs);
+    // 30 minutes before fixed time -> fresh
+    const result = computeStalenessHint(fixedMs - 30 * 60 * 1000);
+    expect(result).toBe('fresh');
+    vi.useRealTimers();
+  });
+});

--- a/src/04-widgets/freshness-badge/lib/compute-staleness-hint.ts
+++ b/src/04-widgets/freshness-badge/lib/compute-staleness-hint.ts
@@ -1,0 +1,27 @@
+import type { StalenessHint } from '@04-widgets/freshness-badge/model/types';
+
+const ONE_HOUR = 60 * 60 * 1000;
+const ONE_DAY = 24 * ONE_HOUR;
+const THREE_DAYS = 3 * ONE_DAY;
+const SEVEN_DAYS = 7 * ONE_DAY;
+
+export function computeStalenessHint(
+  createdAtMs: number,
+  nowMs: number = Date.now()
+): StalenessHint {
+  // NaN/Infinity 입력은 expired로 fallback + dev 경고 (props 타입은 number 강제이나 런타임 방어)
+  if (!Number.isFinite(createdAtMs)) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(
+        `[FreshnessBadge] invalid createdAtMs: ${createdAtMs} -> expired`
+      );
+    }
+    return 'expired';
+  }
+  const diff = Math.max(0, nowMs - createdAtMs); // 미래 시점(음수) clamp -> fresh
+  if (diff <= ONE_HOUR) return 'fresh';
+  if (diff <= ONE_DAY) return 'stable';
+  if (diff <= THREE_DAYS) return 'aging';
+  if (diff <= SEVEN_DAYS) return 'stale';
+  return 'expired';
+}

--- a/src/04-widgets/freshness-badge/lib/format-relative-time.test.ts
+++ b/src/04-widgets/freshness-badge/lib/format-relative-time.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { formatRelativeTime } from '@04-widgets/freshness-badge/lib/format-relative-time';
+
+const SEC = 1000;
+const MIN = 60 * SEC;
+const HOUR = 60 * MIN;
+const DAY = 24 * HOUR;
+const MONTH = 30 * DAY;
+
+const NOW = 1_000_000_000_000;
+
+// Intl.RelativeTimeFormat('ko', { numeric: 'auto' }) actual outputs (verified 2026-05-29):
+// -1 minute  => '1분 전'
+// -2 minute  => '2분 전'
+// -30 minute => '30분 전'
+// -59 minute => '59분 전'
+// -1 hour    => '1시간 전'
+// -2 hour    => '2시간 전'
+// -12 hour   => '12시간 전'
+// -23 hour   => '23시간 전'
+// -1 day     => '어제'       (numeric:'auto' special word)
+// -2 day     => '그저께'     (numeric:'auto' special word)
+// -3 day     => '3일 전'
+// -7 day     => '7일 전'
+// -1 month   => '지난달'     (numeric:'auto' special word)
+// -2 month   => '2개월 전'
+// -6 month   => '6개월 전'
+
+describe('formatRelativeTime — 방금 branch (diff < 60s)', () => {
+  it('diff=0 -> 방금', () => {
+    expect(formatRelativeTime(NOW, NOW)).toBe('방금');
+  });
+
+  it('diff=30s -> 방금', () => {
+    expect(formatRelativeTime(NOW - 30 * SEC, NOW)).toBe('방금');
+  });
+
+  it('diff=59s -> 방금', () => {
+    expect(formatRelativeTime(NOW - 59 * SEC, NOW)).toBe('방금');
+  });
+
+  it('diff=59999ms (just under 1 minute) -> 방금', () => {
+    expect(formatRelativeTime(NOW - 59_999, NOW)).toBe('방금');
+  });
+});
+
+describe('formatRelativeTime — minute branch', () => {
+  it('diff=1min exactly -> 1분 전', () => {
+    expect(formatRelativeTime(NOW - MIN, NOW)).toBe('1분 전');
+  });
+
+  it('diff=2min -> 2분 전', () => {
+    expect(formatRelativeTime(NOW - 2 * MIN, NOW)).toBe('2분 전');
+  });
+
+  it('diff=30min -> 30분 전', () => {
+    expect(formatRelativeTime(NOW - 30 * MIN, NOW)).toBe('30분 전');
+  });
+
+  it('diff=59min -> 59분 전', () => {
+    expect(formatRelativeTime(NOW - 59 * MIN, NOW)).toBe('59분 전');
+  });
+});
+
+describe('formatRelativeTime — hour branch', () => {
+  it('diff=1hour -> 1시간 전', () => {
+    expect(formatRelativeTime(NOW - HOUR, NOW)).toBe('1시간 전');
+  });
+
+  it('diff=2hour -> 2시간 전', () => {
+    expect(formatRelativeTime(NOW - 2 * HOUR, NOW)).toBe('2시간 전');
+  });
+
+  it('diff=12hour -> 12시간 전', () => {
+    expect(formatRelativeTime(NOW - 12 * HOUR, NOW)).toBe('12시간 전');
+  });
+
+  it('diff=23hour -> 23시간 전', () => {
+    expect(formatRelativeTime(NOW - 23 * HOUR, NOW)).toBe('23시간 전');
+  });
+});
+
+describe('formatRelativeTime — day branch', () => {
+  // Intl numeric:'auto' produces special words for -1 and -2
+  it('diff=1day -> 어제 (numeric:auto special word)', () => {
+    expect(formatRelativeTime(NOW - DAY, NOW)).toBe('어제');
+  });
+
+  it('diff=2day -> 그저께 (numeric:auto special word)', () => {
+    expect(formatRelativeTime(NOW - 2 * DAY, NOW)).toBe('그저께');
+  });
+
+  it('diff=3day -> 3일 전', () => {
+    expect(formatRelativeTime(NOW - 3 * DAY, NOW)).toBe('3일 전');
+  });
+
+  it('diff=7day -> 7일 전', () => {
+    expect(formatRelativeTime(NOW - 7 * DAY, NOW)).toBe('7일 전');
+  });
+});
+
+describe('formatRelativeTime — month branch', () => {
+  // Intl numeric:'auto' produces '지난달' for -1 month
+  it('diff=1month -> 지난달 (numeric:auto special word)', () => {
+    expect(formatRelativeTime(NOW - MONTH, NOW)).toBe('지난달');
+  });
+
+  it('diff=2month -> 2개월 전', () => {
+    expect(formatRelativeTime(NOW - 2 * MONTH, NOW)).toBe('2개월 전');
+  });
+
+  it('diff=6month -> 6개월 전', () => {
+    expect(formatRelativeTime(NOW - 6 * MONTH, NOW)).toBe('6개월 전');
+  });
+
+  it('very large diff (2 years) -> month branch, ko locale', () => {
+    expect(formatRelativeTime(NOW - 24 * MONTH, NOW)).toBe('24개월 전');
+  });
+});
+
+describe('formatRelativeTime — ko locale correctness', () => {
+  it('returns Korean string containing 전 for non-recent times', () => {
+    const result = formatRelativeTime(NOW - 5 * MIN, NOW);
+    // '5분 전' must contain Korean text
+    expect(result).toBe('5분 전');
+    expect(result).toMatch(/전$/);
+  });
+});

--- a/src/04-widgets/freshness-badge/lib/format-relative-time.ts
+++ b/src/04-widgets/freshness-badge/lib/format-relative-time.ts
@@ -1,0 +1,18 @@
+const rtf = new Intl.RelativeTimeFormat('ko', { numeric: 'auto' });
+const MIN = 60 * 1000;
+const HOUR = 60 * MIN;
+const DAY = 24 * HOUR;
+const MONTH = 30 * DAY;
+
+/** "방금" / "N분 전" / "N시간 전" / "N일 전" / "N개월 전" */
+export function formatRelativeTime(
+  createdAtMs: number,
+  nowMs: number = Date.now()
+): string {
+  const diff = Math.max(0, nowMs - createdAtMs);
+  if (diff < MIN) return '방금';
+  if (diff < HOUR) return rtf.format(-Math.floor(diff / MIN), 'minute');
+  if (diff < DAY) return rtf.format(-Math.floor(diff / HOUR), 'hour');
+  if (diff < MONTH) return rtf.format(-Math.floor(diff / DAY), 'day');
+  return rtf.format(-Math.floor(diff / MONTH), 'month');
+}

--- a/src/04-widgets/freshness-badge/model/types.ts
+++ b/src/04-widgets/freshness-badge/model/types.ts
@@ -1,0 +1,8 @@
+export type StalenessHint = 'fresh' | 'stable' | 'aging' | 'stale' | 'expired';
+
+export interface FreshnessBadgeProps {
+  /** 검증 완료 시각 (epoch ms). BE verification_results.verified_at 매핑 예정 (Phase 64). */
+  createdAtMs: number;
+  /** 테스트/SSR 주입용. 기본값 런타임 Date.now(). */
+  nowMs?: number;
+}

--- a/src/04-widgets/freshness-badge/ui/badge-skeleton.tsx
+++ b/src/04-widgets/freshness-badge/ui/badge-skeleton.tsx
@@ -1,0 +1,7 @@
+import styles from '@04-widgets/freshness-badge/ui/freshness-badge.module.css';
+
+export function BadgeSkeleton() {
+  return (
+    <span className={`${styles.badge} ${styles.skeleton}`} aria-hidden="true" />
+  );
+}

--- a/src/04-widgets/freshness-badge/ui/freshness-badge.module.css
+++ b/src/04-widgets/freshness-badge/ui/freshness-badge.module.css
@@ -1,0 +1,79 @@
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-6);
+  padding: var(--spacing-6) var(--spacing-8);
+  border-radius: 999px;
+  border-left: 3px solid transparent;
+  font-size: var(--font-label-size);
+  font-family: var(--font-family-base);
+  color: var(--color-text-primary);
+  white-space: nowrap;
+}
+
+.icon {
+  line-height: 1;
+}
+
+.label {
+  font-weight: 600;
+}
+
+.dot {
+  color: var(--color-text-secondary);
+}
+
+.relative {
+  color: var(--color-text-secondary);
+}
+
+.badge-fresh {
+  background: var(--color-success-subtle);
+  border-left-color: var(--color-success-strong);
+}
+
+.badge-fresh .icon {
+  color: var(--color-success-strong);
+}
+
+.badge-stable {
+  background: var(--color-bg-surface-raised);
+  border-left-color: var(--color-info);
+}
+
+.badge-stable .icon {
+  color: var(--color-info);
+}
+
+.badge-aging {
+  background: var(--color-aging-subtle);
+  border-left-color: var(--color-aging-strong);
+}
+
+.badge-aging .icon {
+  color: var(--color-aging-strong);
+}
+
+.badge-stale {
+  background: var(--color-warning-subtle);
+  border-left-color: var(--color-warning-strong);
+}
+
+.badge-stale .icon {
+  color: var(--color-warning-strong);
+}
+
+.badge-expired {
+  background: var(--color-error-subtle);
+  border-left-color: var(--color-error);
+}
+
+.badge-expired .icon {
+  color: var(--color-error);
+}
+
+.skeleton {
+  width: var(--spacing-48);
+  height: var(--spacing-20);
+  background: var(--color-bg-surface-sunken);
+}

--- a/src/04-widgets/freshness-badge/ui/freshness-badge.module.css
+++ b/src/04-widgets/freshness-badge/ui/freshness-badge.module.css
@@ -38,11 +38,11 @@
 
 .badge-stable {
   background: var(--color-bg-surface-raised);
-  border-left-color: var(--color-info);
+  border-left-color: var(--color-brand-secondary);
 }
 
 .badge-stable .icon {
-  color: var(--color-info);
+  color: var(--color-brand-secondary);
 }
 
 .badge-aging {

--- a/src/04-widgets/freshness-badge/ui/freshness-badge.stories.tsx
+++ b/src/04-widgets/freshness-badge/ui/freshness-badge.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { FreshnessBadge } from '@/04-widgets/freshness-badge';
+
+const meta = {
+  title: '04-widgets/FreshnessBadge',
+  component: FreshnessBadge,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof FreshnessBadge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const BASE = 0;
+
+export const Fresh: Story = {
+  args: {
+    createdAtMs: BASE,
+    nowMs: 30 * 60 * 1000,
+  },
+};
+
+export const Stable: Story = {
+  args: {
+    createdAtMs: BASE,
+    nowMs: 12 * 60 * 60 * 1000,
+  },
+};
+
+export const Aging: Story = {
+  args: {
+    createdAtMs: BASE,
+    nowMs: 2 * 24 * 60 * 60 * 1000,
+  },
+};
+
+export const Stale: Story = {
+  args: {
+    createdAtMs: BASE,
+    nowMs: 5 * 24 * 60 * 60 * 1000,
+  },
+};
+
+export const Expired: Story = {
+  args: {
+    createdAtMs: BASE,
+    nowMs: 12 * 24 * 60 * 60 * 1000,
+  },
+};

--- a/src/04-widgets/freshness-badge/ui/freshness-badge.test.tsx
+++ b/src/04-widgets/freshness-badge/ui/freshness-badge.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { FreshnessBadge } from '@04-widgets/freshness-badge/ui/freshness-badge';
+
+afterEach(cleanup);
+
+// Fixed timestamps for deterministic hint computation (no wall-clock dependency)
+const NOW = 1_000_000_000_000;
+const THIRTY_MIN_AGO = NOW - 30 * 60 * 1000; // fresh
+const TWO_DAYS_AGO = NOW - 2 * 24 * 60 * 60 * 1000; // aging
+
+describe('FreshnessBadge — hint label after mount', () => {
+  it('shows "최신" label for a fresh createdAtMs+nowMs pair', async () => {
+    render(<FreshnessBadge createdAtMs={THIRTY_MIN_AGO} nowMs={NOW} />);
+    // useEffect runs after mount; waitFor polls until condition passes
+    await waitFor(() => {
+      const label = screen.getByText('최신');
+      expect(label).toBeDefined();
+    });
+  });
+});
+
+describe('FreshnessBadge — role=status aria-label', () => {
+  it('rendered badge has role="status" with aria-label containing relative time', async () => {
+    render(<FreshnessBadge createdAtMs={THIRTY_MIN_AGO} nowMs={NOW} />);
+    await waitFor(() => {
+      // Use getAllByRole to be resilient if cleanup timing differs
+      const badges = screen.getAllByRole('status');
+      expect(badges.length).toBeGreaterThan(0);
+      const badge = badges[0]!;
+      const ariaLabel = badge.getAttribute('aria-label') ?? '';
+      // aria-label = "{ariaPrefix} · {relative}" e.g. "검증 최신 · 30분 전"
+      expect(ariaLabel).toContain('검증 최신');
+      expect(ariaLabel).toContain('분 전');
+    });
+  });
+});
+
+describe('FreshnessBadge — skeleton-to-badge transition', () => {
+  it('skeleton rendered initially (aria-hidden=true), then role=status badge appears after effect', async () => {
+    const { container } = render(
+      <FreshnessBadge createdAtMs={TWO_DAYS_AGO} nowMs={NOW} />
+    );
+
+    // In the browser environment useEffect may fire synchronously in React 19 concurrent mode.
+    // We verify two invariants that hold regardless of timing:
+    // 1. After effect: role=status badge must exist with the correct label
+    // 2. There is no skeleton (aria-hidden span without role) visible when the badge is shown
+    await waitFor(() => {
+      expect(screen.getAllByRole('status').length).toBeGreaterThan(0);
+    });
+
+    // Badge for aging should show "노후화"
+    await waitFor(() => {
+      const badge = screen.getAllByRole('status')[0]!;
+      const ariaLabel = badge.getAttribute('aria-label') ?? '';
+      expect(ariaLabel).toContain('검증 노후화');
+    });
+
+    // BadgeSkeleton (aria-hidden span with class skeleton) is NOT present once badge shows
+    const skeleton = container.querySelector('.skeleton, [class*="skeleton"]');
+    expect(skeleton).toBeNull();
+  });
+});

--- a/src/04-widgets/freshness-badge/ui/freshness-badge.test.tsx
+++ b/src/04-widgets/freshness-badge/ui/freshness-badge.test.tsx
@@ -37,7 +37,7 @@ describe('FreshnessBadge — role=status aria-label', () => {
 });
 
 describe('FreshnessBadge — skeleton-to-badge transition', () => {
-  it('skeleton rendered initially (aria-hidden=true), then role=status badge appears after effect', async () => {
+  it('renders role=status badge with correct label after effect and shows no skeleton', async () => {
     const { container } = render(
       <FreshnessBadge createdAtMs={TWO_DAYS_AGO} nowMs={NOW} />
     );

--- a/src/04-widgets/freshness-badge/ui/freshness-badge.tsx
+++ b/src/04-widgets/freshness-badge/ui/freshness-badge.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type {
+  FreshnessBadgeProps,
+  StalenessHint,
+} from '@04-widgets/freshness-badge/model/types';
+import { computeStalenessHint } from '@04-widgets/freshness-badge/lib/compute-staleness-hint';
+import { formatRelativeTime } from '@04-widgets/freshness-badge/lib/format-relative-time';
+import { BADGE_CONFIG } from '@04-widgets/freshness-badge/lib/badge-config';
+import { BadgeSkeleton } from '@04-widgets/freshness-badge/ui/badge-skeleton';
+import styles from '@04-widgets/freshness-badge/ui/freshness-badge.module.css';
+
+export function FreshnessBadge({ createdAtMs, nowMs }: FreshnessBadgeProps) {
+  const [hint, setHint] = useState<StalenessHint | null>(null);
+  const [relative, setRelative] = useState<string>('');
+
+  useEffect(() => {
+    setHint(computeStalenessHint(createdAtMs, nowMs));
+    setRelative(formatRelativeTime(createdAtMs, nowMs));
+  }, [createdAtMs, nowMs]);
+
+  if (hint === null) return <BadgeSkeleton />;
+
+  const v = BADGE_CONFIG[hint];
+  return (
+    <span
+      role="status"
+      aria-label={`${v.ariaPrefix} · ${relative}`}
+      className={`${styles.badge} ${styles[v.className]}`}
+    >
+      <span aria-hidden="true" className={styles.icon}>
+        {v.icon}
+      </span>
+      <span className={styles.label}>{v.label}</span>
+      <span aria-hidden="true" className={styles.dot}>
+        ·
+      </span>
+      <span className={styles.relative}>{relative}</span>
+    </span>
+  );
+}

--- a/src/04-widgets/index.ts
+++ b/src/04-widgets/index.ts
@@ -5,3 +5,4 @@ export { Navbar } from './navbar';
 export { Footer } from './footer';
 export { ArticleCard } from './article-card';
 export { ResultCard } from './result-card';
+export { FreshnessBadge } from './freshness-badge';

--- a/src/07-shared/styles/tokens.css
+++ b/src/07-shared/styles/tokens.css
@@ -23,6 +23,10 @@
   --color-green-50: #f0fdf4;
   --color-red-600: #dc2626;
   --color-red-50: #fef2f2;
+  --color-orange-400: #fb923c;
+  --color-orange-50: #fff7ed;
+  --color-amber-500: #f59e0b;
+  --color-amber-50: #fffbeb;
 
   /* --------------------------------------------------
    * Semantic Tokens — 항상 이것을 사용
@@ -69,6 +73,10 @@
   --color-success-subtle: var(--color-green-50);
   --color-error: var(--color-red-600);
   --color-error-subtle: var(--color-red-50);
+  --color-aging-strong: var(--color-orange-400);
+  --color-aging-subtle: var(--color-orange-50);
+  --color-warning-strong: var(--color-amber-500);
+  --color-warning-subtle: var(--color-amber-50);
 
   /* --------------------------------------------------
    * Typography Tokens

--- a/src/07-shared/styles/tokens.css
+++ b/src/07-shared/styles/tokens.css
@@ -23,9 +23,9 @@
   --color-green-50: #f0fdf4;
   --color-red-600: #dc2626;
   --color-red-50: #fef2f2;
-  --color-orange-400: #fb923c;
+  --color-orange-600: #ea580c;
   --color-orange-50: #fff7ed;
-  --color-amber-500: #f59e0b;
+  --color-amber-600: #d97706;
   --color-amber-50: #fffbeb;
 
   /* --------------------------------------------------
@@ -73,9 +73,9 @@
   --color-success-subtle: var(--color-green-50);
   --color-error: var(--color-red-600);
   --color-error-subtle: var(--color-red-50);
-  --color-aging-strong: var(--color-orange-400);
+  --color-aging-strong: var(--color-orange-600);
   --color-aging-subtle: var(--color-orange-50);
-  --color-warning-strong: var(--color-amber-500);
+  --color-warning-strong: var(--color-amber-600);
   --color-warning-subtle: var(--color-amber-50);
 
   /* --------------------------------------------------

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -67,6 +67,7 @@ export default defineConfig({
             'src/05-features/**/__tests__/**/*.test.{ts,tsx}',
             'src/05-features/**/model/**/*.test.ts',
             'src/05-features/**/api*.test.ts',
+            'src/04-widgets/**/lib/**/*.test.ts',
             'test/architecture.test.ts',
           ],
         },


### PR DESCRIPTION
<!-- SAFE_OP_START -->
Assumptions: 검증 시각 입력은 클라이언트 epoch ms (BE verification_results.verified_at 매핑은 Phase 64). createdAtMs+nowMs prop 주입으로 결정적 렌더.
Scope: src/04-widgets/freshness-badge/ (신규), src/07-shared/styles/tokens.css, .claude/rules/design.md, src/04-widgets/index.ts, vitest.config.ts
Out-of-scope: ResultCard 등 사용처 wire (Phase 64), Playwright E2E (사용처 부재), BE staleness 계약
<!-- SAFE_OP_END -->

## Done

- [x] **요구사항 목록**: createdAtMs 기준 5-bucket 노후도(fresh/stable/aging/stale/expired, 임계 1h/24h/3d/7d) 표시 + 상대 시간 병기. 경계값/미래시점 clamp/NaN→expired 처리. hydration-safe(useEffect 마운트 후 계산, 마운트 전 skeleton).
- [x] **산출물 목록**: FreshnessBadge widget(types/compute/format/badge-config/ui/skeleton/css/barrel), Storybook 5 스토리, 단위+UI 테스트 3파일, aging/warning 디자인 토큰, ADR-024(workspace).
- [x] **수용 테스트**: vitest 99 passed(신규 compute 18 + format 20 + UI 3). 회귀 시뮬 ABC(state/logic/contract) 무력화→fail→복구→pass 6 로그. WCAG accent 5색 3:1 통과.

## Behavior Gates 자체 점검

- [x] Gate 1 — Goal Defined
- [x] Gate 2 — Assumption Surfaced (SAFE_OP)
- [x] Gate 3 — Surgical Diff (freshness-badge 신규 + 명시 amend만)
- [x] Gate 4 — Minimum Code (요청 외 추상화 없음)

---

## 관련 Issue
closes #48

## 변경 사항

Phase 62 FE #48 FreshnessBadge widget (표시 UI 한정).

- 5-bucket 노후도 순수 함수 `computeStalenessHint` (1h/24h/3d/7d, 미래 clamp, NaN→expired)
- `formatRelativeTime` (Intl.RelativeTimeFormat ko, 번들 0 추가)
- `FreshnessBadge` hydration-safe (useState(null)+useEffect, 마운트 전 skeleton, role=status)
- 신규 상태 토큰 aging(orange)/warning(amber) + design.md 상태색 항목 amend
- WCAG: 텍스트 19:1 이상, accent 5색 3:1 통과 (미달 3색 darken: stable=blue-700, aging=orange-600, stale=amber-600)
- 색 단독 의존 금지(1.4.1): 아이콘 모양 + 라벨 문구 + bg tint + 좌border + accent 5중 신호
- Storybook 5 스토리(결정적 args), barrel은 컴포넌트+타입만 노출(lib 캡슐화)
- ADR-024 박제 (workspace context/decisions, FE git 외부)

상세 근거: `.plans/62-fe48-freshness-badge-2026-05-28/` (DISCUSS/PLAN/CRITIQUE/CHECKLIST + plan-review 2라운드 + 회귀 시뮬 로그)

## 체크리스트
- [x] 빌드 성공 (7 라우트)
- [x] 관련 테스트 통과 (vitest 99 passed)
- [x] Issue의 수용 기준 모두 충족
- [x] 불필요한 console.log 제거 (dev-only console.warn은 NaN 방어 의도)

## 스크린샷 (UI 변경 시)
Storybook 5 스토리로 5-bucket 시각 확인 가능 (Fresh/Stable/Aging/Stale/Expired).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 콘텐츠의 신선도를 표시하는 신선도 배지 위젯 추가 (최신, 안정, 노후, 오래됨, 만료됨 상태 포함)
  * 상대 시간 표시 기능 추가 (예: "5분 전", "어제")

* **스타일**
  * 디자인 토큰에 노후도/경고 상태 색상 변수 추가
  * 신선도 배지 스타일시트 추가

* **테스트**
  * 신선도 배지 컴포넌트 및 유틸리티 함수에 대한 단위 테스트 추가

* **문서**
  * 신선도 배지 컴포넌트의 스토리북 문서 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/truthscope-smu/truthscope-web-frontend/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->