### PR TITLE
✨feat(result-card): #46 ArticleFactScore + SiftMapping + PartialFailureDisplay 통합 (phase 57~60 정렬)

### DIFF
--- a/src/04-widgets/article-fact-score/index.ts
+++ b/src/04-widgets/article-fact-score/index.ts
@@ -1,0 +1,2 @@
+export { ArticleFactScore } from './ui/article-fact-score';
+export type { ArticleFactScoreSnapshot } from './model/types';

--- a/src/04-widgets/article-fact-score/model/types.ts
+++ b/src/04-widgets/article-fact-score/model/types.ts
@@ -1,0 +1,17 @@
+/**
+ * ArticleFactScore widget 도메인 타입. ADR-019 + Phase 55 정합.
+ *
+ * BE 매핑: truthscope-web-backend/core/.../scoring/{ArticleFactScore,CoverageSummary}.java
+ * - ArticleFactScore(value): 0..100 정수 (검증 가능 claim 존재 시).
+ * - CoverageSummary(scorableCount, excludedCount, ...): 검증 가능 + 제외 count.
+ *
+ * value undefined = aggregateArticleFactScore가 Optional.empty 반환 = "검증 가능 주장 없음" 상태.
+ */
+export interface ArticleFactScoreSnapshot {
+  /** 0..100 정수. undefined일 때 "검증 가능 주장 없음" 표시 (BE Optional.empty). */
+  value?: number;
+  /** 검증 가능 claim 수 (CoverageSummary.scorableCount). */
+  scorableCount?: number;
+  /** 전체 claim 수 (scorableCount + excludedCount). coverage "N개 중 M개 기준" 텍스트 생성용. */
+  totalClaimCount?: number;
+}

--- a/src/04-widgets/article-fact-score/ui/article-fact-score.stories.tsx
+++ b/src/04-widgets/article-fact-score/ui/article-fact-score.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { ArticleFactScore } from '@/04-widgets/article-fact-score';
+
+const meta = {
+  title: '04-widgets/ArticleFactScore',
+  component: ArticleFactScore,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof ArticleFactScore>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { snapshot: { value: 68, scorableCount: 4, totalClaimCount: 5 } },
+};
+
+export const FloorZero: Story = {
+  args: { snapshot: { value: 0, scorableCount: 3, totalClaimCount: 3 } },
+};
+
+export const Empty: Story = {
+  args: {
+    snapshot: { value: undefined, scorableCount: 0, totalClaimCount: 5 },
+  },
+};
+
+export const HighScore: Story = {
+  args: { snapshot: { value: 92, scorableCount: 4, totalClaimCount: 4 } },
+};
+
+export const Skeleton: Story = {
+  args: { snapshot: undefined },
+};

--- a/src/04-widgets/article-fact-score/ui/article-fact-score.tsx
+++ b/src/04-widgets/article-fact-score/ui/article-fact-score.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useId } from 'react';
+import { cn } from '@/07-shared/lib/cn';
+import type { ArticleFactScoreSnapshot } from '@04-widgets/article-fact-score/model/types';
+
+interface Props {
+  snapshot?: ArticleFactScoreSnapshot;
+  className?: string;
+}
+
+const SCORE_LABEL = '검증 가능 주장 기준 종합 점수';
+const EMPTY_LABEL = '검증 가능 주장 없음';
+const EMPTY_CAPTION = '기사 종합 점수 산출 불가';
+
+export function ArticleFactScore({ snapshot, className }: Props) {
+  const titleId = useId();
+
+  if (!snapshot) {
+    return <ArticleFactScoreSkeleton className={className} />;
+  }
+
+  const hasScore = typeof snapshot.value === 'number';
+  const hasCoverage =
+    typeof snapshot.scorableCount === 'number' &&
+    typeof snapshot.totalClaimCount === 'number';
+
+  return (
+    <section
+      aria-labelledby={titleId}
+      className={cn(
+        'flex flex-col items-center gap-[var(--spacing-8)] rounded-lg border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface-base)] p-[var(--spacing-24)] text-center',
+        className
+      )}
+    >
+      {hasScore ? (
+        <>
+          <strong
+            id={titleId}
+            aria-label={`${SCORE_LABEL} ${snapshot.value}점`}
+            className="text-[68px] font-semibold leading-none text-[var(--color-action-hero)] tabular-nums"
+          >
+            {snapshot.value}
+          </strong>
+          <span className="text-xs text-[var(--color-text-secondary)]">
+            {SCORE_LABEL}
+          </span>
+          {hasCoverage && (
+            <span
+              aria-label={`검증 가능 주장 ${snapshot.totalClaimCount}개 중 ${snapshot.scorableCount}개 기준`}
+              className="text-xs text-[var(--color-text-secondary)] tabular-nums"
+            >
+              검증 가능 {snapshot.totalClaimCount}개 중 {snapshot.scorableCount}
+              개 기준
+            </span>
+          )}
+        </>
+      ) : (
+        <>
+          <strong
+            id={titleId}
+            className="text-[28px] font-semibold text-[var(--color-text-primary)]"
+          >
+            {EMPTY_LABEL}
+          </strong>
+          <span className="text-xs text-[var(--color-text-secondary)]">
+            {EMPTY_CAPTION}
+          </span>
+        </>
+      )}
+    </section>
+  );
+}
+
+function ArticleFactScoreSkeleton({ className }: { className?: string }) {
+  return (
+    <section
+      aria-hidden="true"
+      className={cn(
+        'flex flex-col items-center gap-[var(--spacing-8)] rounded-lg border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface-base)] p-[var(--spacing-24)]',
+        className
+      )}
+    >
+      <span className="block h-[68px] w-[100px] animate-pulse rounded bg-[var(--color-bg-surface-sunken)]" />
+      <span className="block h-3 w-[200px] animate-pulse rounded bg-[var(--color-bg-surface-sunken)]" />
+      <span className="block h-3 w-[160px] animate-pulse rounded bg-[var(--color-bg-surface-sunken)]" />
+    </section>
+  );
+}

--- a/src/04-widgets/partial-failure-display/index.ts
+++ b/src/04-widgets/partial-failure-display/index.ts
@@ -1,0 +1,6 @@
+export { PartialFailureDisplay } from './ui/partial-failure-display';
+export type {
+  PartialFailureSnapshot,
+  Tier3Reason,
+  SourceTransparencyBand,
+} from './model/types';

--- a/src/04-widgets/partial-failure-display/model/types.ts
+++ b/src/04-widgets/partial-failure-display/model/types.ts
@@ -1,0 +1,53 @@
+/**
+ * 부분 실패 + 신뢰도 분리 표시 widget 도메인 타입.
+ * 면담 D-D(부분 실패 투명 표시) + sprint-4-amendment N-5 정합.
+ *
+ * BE 매핑:
+ * - coverage: core/scoring/CoverageSummary.java
+ * - sourceTransparency: core/scoring/SourceTransparencySummary.java
+ * - uniqueSourceCount: BE 정본 미존재 — #46 통합 phase에서 cascade source_count 집계 파생 매핑.
+ *
+ * 부재 시 fallback (절충안 A' 안전 contract):
+ * - coverage 부재 → skeleton.
+ * - sourceTransparency 부재 → I 섹션 hide.
+ * - uniqueSourceCount 부재 → 단일 출처 경고 섹션 hide (placeholder 노출 회피).
+ *
+ * Optional 필드 의미 (CX-4 정합):
+ * - exactOptionalPropertyTypes 미설정 환경 (tsconfig.json strict=true / 미설정).
+ * - 따라서 `uniqueSourceCount: undefined`와 필드 부재(absent)를 동일 처리.
+ * - 본 widget의 분기 조건 `=== undefined` 또는 `=== 1` 만 검사 — 양쪽 모두 안전.
+ */
+
+export type Tier3Reason = 'INSUFFICIENT' | 'TIME_SENSITIVE' | 'OUT_OF_SCOPE';
+
+export type SourceTransparencyBand =
+  | 'ALL_EXPLICIT'
+  | 'SOME_UNCLEAR'
+  | 'MISSING_SOURCE';
+
+/**
+ * 사유 row 키 — `CoverageSummary` 사유별 count 3개 한정 (tier1/2/3Count 제외).
+ * REASON_ROWS narrowing + Tier3Reason 매핑 bridge용 (Round 1 CX-2 + CX-3 정합).
+ */
+export type ReasonCountKey =
+  | 'insufficientCount'
+  | 'timeSensitiveCount'
+  | 'outOfScopeCount';
+
+export interface PartialFailureSnapshot {
+  coverage?: {
+    insufficientCount: number;
+    timeSensitiveCount: number;
+    outOfScopeCount: number;
+    tier1Count: number;
+    tier2Count: number;
+    tier3Count: number;
+  };
+  sourceTransparency?: {
+    band: SourceTransparencyBand;
+    explicitCount: number;
+    ambiguousCount: number;
+    noneCount: number;
+  };
+  uniqueSourceCount?: number;
+}

--- a/src/04-widgets/partial-failure-display/ui/partial-failure-display.stories.tsx
+++ b/src/04-widgets/partial-failure-display/ui/partial-failure-display.stories.tsx
@@ -1,0 +1,146 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { PartialFailureDisplay } from '@/04-widgets/partial-failure-display';
+
+const meta = {
+  title: '04-widgets/PartialFailureDisplay',
+  component: PartialFailureDisplay,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof PartialFailureDisplay>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Storybook 케이스: 5건 BE 정본 + 1건 mock + 1 Skeleton = 7 케이스 (절충안 A' 안전 우선)
+
+export const Default: Story = {
+  args: {
+    snapshot: {
+      coverage: {
+        insufficientCount: 0,
+        timeSensitiveCount: 0,
+        outOfScopeCount: 0,
+        tier1Count: 5,
+        tier2Count: 3,
+        tier3Count: 0,
+      },
+      sourceTransparency: {
+        band: 'ALL_EXPLICIT',
+        explicitCount: 5,
+        ambiguousCount: 0,
+        noneCount: 0,
+      },
+    },
+  },
+};
+
+export const PartialInsufficient: Story = {
+  args: {
+    snapshot: {
+      coverage: {
+        insufficientCount: 3,
+        timeSensitiveCount: 0,
+        outOfScopeCount: 0,
+        tier1Count: 5,
+        tier2Count: 3,
+        tier3Count: 3,
+      },
+      sourceTransparency: {
+        band: 'SOME_UNCLEAR',
+        explicitCount: 4,
+        ambiguousCount: 2,
+        noneCount: 0,
+      },
+    },
+  },
+};
+
+export const PartialMixed: Story = {
+  args: {
+    snapshot: {
+      coverage: {
+        insufficientCount: 2,
+        timeSensitiveCount: 1,
+        outOfScopeCount: 1,
+        tier1Count: 4,
+        tier2Count: 2,
+        tier3Count: 4,
+      },
+      sourceTransparency: {
+        band: 'SOME_UNCLEAR',
+        explicitCount: 3,
+        ambiguousCount: 3,
+        noneCount: 1,
+      },
+    },
+  },
+};
+
+export const MissingSource: Story = {
+  args: {
+    snapshot: {
+      coverage: {
+        insufficientCount: 1,
+        timeSensitiveCount: 0,
+        outOfScopeCount: 1,
+        tier1Count: 2,
+        tier2Count: 3,
+        tier3Count: 2,
+      },
+      sourceTransparency: {
+        band: 'MISSING_SOURCE',
+        explicitCount: 2,
+        ambiguousCount: 1,
+        noneCount: 2,
+      },
+    },
+  },
+};
+
+export const AllClear: Story = {
+  args: {
+    snapshot: {
+      coverage: {
+        insufficientCount: 0,
+        timeSensitiveCount: 0,
+        outOfScopeCount: 0,
+        tier1Count: 8,
+        tier2Count: 4,
+        tier3Count: 0,
+      },
+      sourceTransparency: {
+        band: 'ALL_EXPLICIT',
+        explicitCount: 12,
+        ambiguousCount: 0,
+        noneCount: 0,
+      },
+    },
+  },
+};
+
+// 절충안 A' 1 mock 케이스 — uniqueSourceCount=1 노출 (선행 시연 + #46 baseline 박제)
+export const SingleSourceWarning: Story = {
+  args: {
+    snapshot: {
+      coverage: {
+        insufficientCount: 0,
+        timeSensitiveCount: 0,
+        outOfScopeCount: 0,
+        tier1Count: 3,
+        tier2Count: 2,
+        tier3Count: 0,
+      },
+      sourceTransparency: {
+        band: 'ALL_EXPLICIT',
+        explicitCount: 5,
+        ambiguousCount: 0,
+        noneCount: 0,
+      },
+      uniqueSourceCount: 1, // mock — #46 통합 phase에서 BE 매핑 의무
+    },
+  },
+};
+
+export const Skeleton: Story = {
+  args: { snapshot: undefined },
+};

--- a/src/04-widgets/partial-failure-display/ui/partial-failure-display.tsx
+++ b/src/04-widgets/partial-failure-display/ui/partial-failure-display.tsx
@@ -1,0 +1,228 @@
+'use client';
+
+import { useId } from 'react';
+import { cn } from '@/07-shared/lib/cn';
+import type {
+  PartialFailureSnapshot,
+  ReasonCountKey,
+  SourceTransparencyBand,
+  Tier3Reason,
+} from '@/04-widgets/partial-failure-display/model/types';
+
+interface Props {
+  snapshot?: PartialFailureSnapshot;
+  className?: string;
+}
+
+const BAND_LABEL: Record<SourceTransparencyBand, string> = {
+  ALL_EXPLICIT: '모두 명시',
+  SOME_UNCLEAR: '일부 불명확',
+  MISSING_SOURCE: '출처 누락 있음',
+};
+
+const BAND_TONE: Record<SourceTransparencyBand, string> = {
+  ALL_EXPLICIT: 'text-[var(--color-success-strong)]',
+  SOME_UNCLEAR: 'text-[var(--color-info)]',
+  MISSING_SOURCE: 'text-[var(--color-error)]',
+};
+
+/**
+ * BE Tier3ReasonCandidate enum → CoverageSummary count 필드 bridge.
+ * BE enum 추가/리네이밍 시 컴파일 에러 발생 의무 (Round 1 CX-3 정합).
+ */
+const TIER3_REASON_TO_COUNT_KEY: Record<Tier3Reason, ReasonCountKey> = {
+  INSUFFICIENT: 'insufficientCount',
+  TIME_SENSITIVE: 'timeSensitiveCount',
+  OUT_OF_SCOPE: 'outOfScopeCount',
+};
+
+interface ReasonRowDef {
+  reason: Tier3Reason;
+  key: ReasonCountKey;
+  label: string;
+  detail: string;
+}
+
+const REASON_ROWS: readonly ReasonRowDef[] = [
+  {
+    reason: 'INSUFFICIENT',
+    key: TIER3_REASON_TO_COUNT_KEY.INSUFFICIENT,
+    label: '검증불가',
+    detail: '근거 부족 또는 Tier 1/2 실패',
+  },
+  {
+    reason: 'TIME_SENSITIVE',
+    key: TIER3_REASON_TO_COUNT_KEY.TIME_SENSITIVE,
+    label: '시점주의',
+    detail: '재검증 필요',
+  },
+  {
+    reason: 'OUT_OF_SCOPE',
+    key: TIER3_REASON_TO_COUNT_KEY.OUT_OF_SCOPE,
+    label: '검증범위 밖',
+    detail: '의견·예측·가치판단',
+  },
+] as const;
+
+const SINGLE_SOURCE_WARNING = '단일 출처 의존 — 교차 출처 확보 권장';
+
+export function PartialFailureDisplay({ snapshot, className }: Props) {
+  const titleId = useId();
+
+  if (!snapshot) {
+    return <PartialFailureSkeleton className={className} />;
+  }
+
+  const coverage = snapshot.coverage;
+  const sourceTransparency = snapshot.sourceTransparency;
+  const uniqueSourceCount = snapshot.uniqueSourceCount;
+
+  const excludedTotal = coverage
+    ? coverage.insufficientCount +
+      coverage.timeSensitiveCount +
+      coverage.outOfScopeCount
+    : 0;
+
+  return (
+    <section
+      aria-labelledby={titleId}
+      className={cn(
+        'flex flex-col rounded-lg border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface-base)] overflow-hidden',
+        className
+      )}
+    >
+      <header className="flex items-center justify-between border-b border-[var(--color-border-subtle)] p-[var(--spacing-16)]">
+        <h3
+          id={titleId}
+          className="m-0 text-base font-semibold text-[var(--color-text-heading)]"
+        >
+          검증 커버리지
+        </h3>
+        <span className="text-xs text-[var(--color-text-secondary)]">N-5</span>
+      </header>
+
+      {/* 사유별 비판정 count */}
+      {coverage && (
+        <div className="flex flex-col p-[var(--spacing-16)] gap-[var(--spacing-10)] border-b border-[var(--color-border-subtle)]">
+          {excludedTotal === 0 ? (
+            <span className="text-sm text-[var(--color-success-strong)]">
+              모든 claim 검증 완료
+            </span>
+          ) : (
+            REASON_ROWS.filter((row) => coverage[row.key] > 0).map((row) => (
+              <ReasonRow
+                key={row.reason}
+                count={coverage[row.key]}
+                label={row.label}
+                detail={row.detail}
+              />
+            ))
+          )}
+        </div>
+      )}
+
+      {/* Tier 분포 */}
+      {coverage && (
+        <div className="flex flex-wrap items-center gap-[var(--spacing-6)] border-b border-[var(--color-border-subtle)] p-[var(--spacing-16)] text-xs text-[var(--color-text-secondary)]">
+          <span className="font-semibold text-[var(--color-text-primary)]">
+            검증 경로:
+          </span>
+          <span>Tier 1 기관 {coverage.tier1Count}건</span>
+          <span aria-hidden="true">·</span>
+          <span>Tier 2 AI 교차 {coverage.tier2Count}건</span>
+          <span aria-hidden="true">·</span>
+          <span>Tier 3 검증불가 {coverage.tier3Count}건</span>
+        </div>
+      )}
+
+      {/* 출처 명시 band */}
+      {sourceTransparency && (
+        <div className="flex flex-col gap-[var(--spacing-6)] border-b border-[var(--color-border-subtle)] p-[var(--spacing-16)]">
+          <span className="text-xs font-semibold text-[var(--color-text-primary)]">
+            출처 명시
+          </span>
+          <span className={cn('text-xs', BAND_TONE[sourceTransparency.band])}>
+            {BAND_LABEL[sourceTransparency.band]} · 명시{' '}
+            {sourceTransparency.explicitCount} · 불명확{' '}
+            {sourceTransparency.ambiguousCount} · 누락{' '}
+            {sourceTransparency.noneCount}
+          </span>
+        </div>
+      )}
+
+      {/* 단일 출처 경고 (절충안 A' 안전 contract: undefined 시 hide) */}
+      {uniqueSourceCount === 1 && (
+        <div
+          role="alert"
+          className="flex items-start gap-[var(--spacing-8)] p-[var(--spacing-16)] bg-[var(--color-bg-surface-sunken)]"
+        >
+          <span
+            aria-hidden="true"
+            className="text-[var(--color-info)] text-base leading-none"
+          >
+            ⚠
+          </span>
+          <span className="text-xs text-[var(--color-info)] leading-relaxed">
+            {SINGLE_SOURCE_WARNING}
+          </span>
+        </div>
+      )}
+    </section>
+  );
+}
+
+interface ReasonRowProps {
+  count: number;
+  label: string;
+  detail: string;
+}
+
+function ReasonRow({ count, label, detail }: ReasonRowProps) {
+  return (
+    <div className="grid grid-cols-[40px_minmax(0,1fr)] gap-[var(--spacing-10)] items-start">
+      <span
+        aria-hidden="true"
+        className="inline-flex h-7 min-w-[40px] items-center justify-center rounded-full border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface-base)] px-[var(--spacing-6)] text-sm font-semibold text-[var(--color-brand-primary)]"
+      >
+        {count}
+      </span>
+      <div className="flex flex-col gap-[var(--spacing-6)]">
+        <strong className="text-sm font-semibold text-[var(--color-text-primary)]">
+          {label} {count}건
+        </strong>
+        <span className="text-xs leading-relaxed text-[var(--color-text-secondary)]">
+          {detail}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function PartialFailureSkeleton({ className }: { className?: string }) {
+  return (
+    <section
+      aria-busy="true"
+      aria-label="검증 커버리지 로딩 중"
+      className={cn(
+        'flex flex-col rounded-lg border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface-base)] overflow-hidden',
+        className
+      )}
+    >
+      <div className="border-b border-[var(--color-border-subtle)] p-[var(--spacing-16)]">
+        <span className="block h-4 w-[140px] animate-pulse rounded bg-[var(--color-bg-surface-sunken)]" />
+      </div>
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div
+          key={i}
+          className="grid grid-cols-[40px_minmax(0,1fr)] gap-[var(--spacing-10)] p-[var(--spacing-16)] border-b border-[var(--color-border-subtle)] last:border-b-0"
+        >
+          <span className="h-7 min-w-[40px] animate-pulse rounded-full bg-[var(--color-bg-surface-sunken)]" />
+          <div className="flex flex-col gap-[var(--spacing-6)]">
+            <span className="block h-3 w-[100px] animate-pulse rounded bg-[var(--color-bg-surface-sunken)]" />
+            <span className="block h-3 w-[200px] animate-pulse rounded bg-[var(--color-bg-surface-sunken)]" />
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/src/04-widgets/result-card/model/types.ts
+++ b/src/04-widgets/result-card/model/types.ts
@@ -1,5 +1,6 @@
 /**
  * ResultCard 도메인 타입. Phase 55 D12 + ADR-014 정합 (5/22 LOCK).
+ * Phase 60 #46 통합: ResultCardSnapshot 3 nested optional 추가 (articleFactScore + siftMapping + partialFailure).
  *
  * - TruthLabel 5종: claim score 산출 가능 시 도출 (Phase 55 deriveTruthLabel).
  * - ClaimScoreStatus 3종: claim score 산출 불가 시 별도 상태 (verdict 5종 중 비판정).
@@ -7,6 +8,10 @@
  * BE 매핑: truthscope-web-backend/core/.../scoring/{TruthLabel,ClaimScoreStatus}.java
  * ADR-014 §5: FE에서 신규 enum 생성 금지, BE 도출값 직접 매핑.
  */
+
+import type { ArticleFactScoreSnapshot } from '@04-widgets/article-fact-score';
+import type { SiftMappingSnapshot } from '@04-widgets/sift-mapping';
+import type { PartialFailureSnapshot } from '@04-widgets/partial-failure-display';
 
 /**
  * 진실성 5종 (claim score 0..100 밴딩에서 도출).
@@ -53,6 +58,22 @@ export interface ContextSnapshot {
 }
 
 export interface ResultCardSnapshot {
+  /**
+   * N-1 sub-component (#41 phase 57 DONE) — 기사 종합 점수.
+   * 시그니처: value? + scorableCount? + totalClaimCount? 3 필드 only (Round 1 C-1/CX-1 amend).
+   * BE 매핑: core/scoring/ArticleFactScore.value (0..100 정수, Optional.empty 시 undefined).
+   */
+  articleFactScore?: ArticleFactScoreSnapshot;
+  /** N-3 sub-component (#42 phase 58 DONE) — SIFT 4단계 매핑. */
+  siftMapping?: SiftMappingSnapshot;
+  /**
+   * N-5 sub-component (#44 phase 59 DONE) — 부분 실패 표시.
+   * coverage 필드는 CoverageSummary 8 필드 중 reason 3 + tier 3 = 6 필드 projection (Round 1 CX-2 명시 박제).
+   * scorableCount/excludedCount는 derive 가능하므로 widget 노출 제외.
+   */
+  partialFailure?: PartialFailureSnapshot;
+  /** 기존 — claim별 진실성 라벨. */
   factCheck?: FactCheckSnapshot;
+  /** 기존 — 맥락 (요약 + 관련 기사 + sourceCount). */
   context?: ContextSnapshot;
 }

--- a/src/04-widgets/result-card/ui/result-card.stories.tsx
+++ b/src/04-widgets/result-card/ui/result-card.stories.tsx
@@ -4,166 +4,205 @@ import { ResultCard } from '@/04-widgets/result-card';
 const meta = {
   title: '04-widgets/ResultCard',
   component: ResultCard,
-  parameters: {
-    layout: 'centered',
-  },
+  parameters: { layout: 'centered' },
   tags: ['autodocs'],
 } satisfies Meta<typeof ResultCard>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Skeleton: Story = {
-  args: {
-    snapshot: undefined,
-  },
-};
+// Storybook 6 케이스 — 5 BE 정본 mock + 1 SingleSource (절충안 A' contract C 무력화 baseline) + 1 Skeleton
 
-export const Fact: Story = {
+// Round 1 C-1/CX-1 amend: ArticleFactScoreSnapshot 정본 시그니처는 value? + scorableCount? + totalClaimCount? 3 필드 only.
+// score / truthLabel 필드 부재 — phase 57 model/types.ts:10-17 정합.
+
+export const NormalScore: Story = {
   args: {
     snapshot: {
+      articleFactScore: { value: 82, scorableCount: 6, totalClaimCount: 8 },
+      siftMapping: {
+        sourceTransparency: {
+          band: 'ALL_EXPLICIT',
+          explicitCount: 5,
+          ambiguousCount: 0,
+          noneCount: 0,
+        },
+        crossSource: { tier1Count: 4, tier2Count: 2, adapterDiversity: 5 },
+        attributionLinks: [
+          { url: 'https://kostat.go.kr', label: '통계청 자료' },
+        ],
+      },
       factCheck: {
         truthLabel: 'FACT',
-        confidence: 92,
-        claim: '공식 통계 기준 전년 대비 수출액이 12.4% 증가했다.',
-        evidence: [
-          '통계청 공식 자료와 수치가 일치합니다.',
-          '관세청 수출입 통계 원문 링크 확보.',
-        ],
+        confidence: 90,
+        claim: '주장 예시',
+        evidence: ['근거 1', '근거 2'],
+      },
+      partialFailure: {
+        coverage: {
+          insufficientCount: 0,
+          timeSensitiveCount: 0,
+          outOfScopeCount: 0,
+          tier1Count: 4,
+          tier2Count: 2,
+          tier3Count: 0,
+        },
+        sourceTransparency: {
+          band: 'ALL_EXPLICIT',
+          explicitCount: 5,
+          ambiguousCount: 0,
+          noneCount: 0,
+        },
       },
       context: {
-        summary:
-          '통계청 발표 자료에 따르면 2026년 1분기 수출액은 전년 동기 대비 12.4% 증가했습니다.',
-        sourceCount: 4,
-        relatedArticles: [
-          { id: '1', title: '관세청 1분기 수출 동향 보고서', source: '관세청' },
-          { id: '2', title: '한국은행 분기별 GDP 발표', source: '한국은행' },
-        ],
+        summary: '요약 본문',
+        relatedArticles: [{ id: '1', title: '관련 기사', source: '통계청' }],
+        sourceCount: 5,
       },
     },
   },
 };
 
-export const MostlyFact: Story = {
+export const ZeroFloor: Story = {
   args: {
     snapshot: {
-      factCheck: {
-        truthLabel: 'MOSTLY_FACT',
-        confidence: 76,
-        claim: '전문가 다수는 해당 정책의 단기 효과를 긍정적으로 봤다.',
-        evidence: ['보고서 방향은 일치하지만 범위가 일부 축약됐습니다.'],
+      articleFactScore: { value: 0, scorableCount: 3, totalClaimCount: 8 },
+      siftMapping: {
+        sourceTransparency: {
+          band: 'MISSING_SOURCE',
+          explicitCount: 1,
+          ambiguousCount: 2,
+          noneCount: 5,
+        },
       },
-      context: {
-        summary: '표본 기간과 비교 대상 설명이 추가로 필요합니다.',
-        sourceCount: 3,
-      },
-    },
-  },
-};
-
-export const PartlyFact: Story = {
-  args: {
-    snapshot: {
-      factCheck: {
-        truthLabel: 'PARTLY_FACT',
-        confidence: 54,
-        claim: '지원금 증가가 청년 고용률 회복의 주된 원인이다.',
-        evidence: ['수치 방향은 맞지만 인과 설명은 확인되지 않았습니다.'],
-      },
-      context: {
-        summary: '다른 경기 변수와 정책 시차가 분리되지 않았습니다.',
-        sourceCount: 2,
-      },
-    },
-  },
-};
-
-export const MostlyNotFact: Story = {
-  args: {
-    snapshot: {
-      factCheck: {
-        truthLabel: 'MOSTLY_NOT_FACT',
-        confidence: 31,
-        claim: '해당 법안은 이미 모든 절차를 통과해 시행 중이다.',
-        evidence: [
-          '상임위 계류 상태로, 시행 중이라는 표현은 부정확합니다.',
-          '일부 조항은 별도 시행령으로 검토 중입니다.',
-        ],
-      },
-      context: {
-        summary: '법안은 입법 절차의 일부만 통과했습니다.',
-        sourceCount: 3,
-      },
-    },
-  },
-};
-
-export const NotFact: Story = {
-  args: {
-    snapshot: {
       factCheck: {
         truthLabel: 'NOT_FACT',
-        confidence: 88,
-        claim: '지난해 같은 지역의 사고 건수는 0건이었다.',
-        evidence: [
-          '공식 사고 통계에 동일 기간 18건이 기록되어 있습니다.',
-          '지자체 공개 자료 + 재난안전 포털 양쪽 모두 18건 확인.',
-        ],
+        confidence: 95,
+        claim: '오류 주장',
+        evidence: ['반박 근거 1', '반박 근거 2'],
       },
-      context: {
-        summary: '지자체 공개 자료 + 재난안전 포털 모두 18건 기록 확인.',
-        sourceCount: 2,
+      partialFailure: {
+        coverage: {
+          insufficientCount: 3,
+          timeSensitiveCount: 1,
+          outOfScopeCount: 1,
+          tier1Count: 0,
+          tier2Count: 3,
+          tier3Count: 5,
+        },
+        sourceTransparency: {
+          band: 'MISSING_SOURCE',
+          explicitCount: 1,
+          ambiguousCount: 2,
+          noneCount: 5,
+        },
       },
+      context: { summary: '에러 톤 요약', sourceCount: 2 },
     },
   },
 };
 
-export const Insufficient: Story = {
+// NoScorable: value 필드 생략 = "검증 가능 주장 없음" 상태 (phase 57 types.ts:11 정합, C-2 amend).
+// evidence 필드 생략 = INSUFFICIENT 시 근거 없음 (Round 2 CX-2 amend, 빈 배열 [] 사용 금지 contract — `evidence?.length` 분기에서 skeleton과 구분 어려움).
+export const NoScorable: Story = {
   args: {
     snapshot: {
-      factCheck: {
-        status: 'INSUFFICIENT',
-        claim: '해당 사건의 책임자는 A 회사이다.',
-        evidence: ['확인 가능한 출처가 1건뿐이며 교차 검증이 어렵습니다.'],
+      articleFactScore: { scorableCount: 0, totalClaimCount: 5 },
+      factCheck: { status: 'INSUFFICIENT', claim: '검증 불가 주장' },
+      partialFailure: {
+        coverage: {
+          insufficientCount: 3,
+          timeSensitiveCount: 1,
+          outOfScopeCount: 1,
+          tier1Count: 0,
+          tier2Count: 0,
+          tier3Count: 5,
+        },
       },
-      context: {
-        summary: '추가 1차 출처가 확인되면 재평가 가능합니다.',
-        sourceCount: 1,
-      },
+      context: { summary: '검증 가능 0개 안내', sourceCount: 2 },
     },
   },
 };
 
-export const TimeSensitive: Story = {
+export const PartialFailure: Story = {
   args: {
     snapshot: {
+      articleFactScore: { value: 65, scorableCount: 4, totalClaimCount: 8 },
+      siftMapping: {
+        sourceTransparency: {
+          band: 'SOME_UNCLEAR',
+          explicitCount: 3,
+          ambiguousCount: 2,
+          noneCount: 1,
+        },
+      },
       factCheck: {
-        status: 'TIME_SENSITIVE',
-        claim: '오늘 기준 환율은 1,380원이다.',
-        evidence: [
-          '실시간 환율 변동성이 커 시점 명시 없이는 사실성 평가가 어렵습니다.',
-        ],
+        truthLabel: 'PARTLY_FACT',
+        confidence: 70,
+        claim: '일부 사실 주장',
+        evidence: ['근거 1'],
       },
-      context: {
-        summary: '시점 정보가 명확해지면 재검증 가능합니다.',
-        sourceCount: 1,
+      partialFailure: {
+        coverage: {
+          insufficientCount: 2,
+          timeSensitiveCount: 1,
+          outOfScopeCount: 1,
+          tier1Count: 2,
+          tier2Count: 2,
+          tier3Count: 4,
+        },
+        sourceTransparency: {
+          band: 'SOME_UNCLEAR',
+          explicitCount: 3,
+          ambiguousCount: 2,
+          noneCount: 1,
+        },
       },
+      context: { summary: '부분 실패 요약', sourceCount: 3 },
     },
   },
 };
 
-export const OutOfScope: Story = {
+// SingleSource — context.sourceCount=1 → partial-failure-display 단일 출처 경고 발화 (절충안 A' contract C 무력화 baseline)
+export const SingleSource: Story = {
   args: {
     snapshot: {
+      articleFactScore: { value: 75, scorableCount: 5, totalClaimCount: 7 },
+      siftMapping: {
+        sourceTransparency: {
+          band: 'ALL_EXPLICIT',
+          explicitCount: 5,
+          ambiguousCount: 0,
+          noneCount: 0,
+        },
+      },
       factCheck: {
-        status: 'OUT_OF_SCOPE',
-        claim: '이 정책은 윤리적으로 옳다.',
-        evidence: ['가치 판단 주장은 사실 검증 범위 밖입니다.'],
+        truthLabel: 'MOSTLY_FACT',
+        confidence: 80,
+        claim: '주장 예시',
+        evidence: ['근거 1'],
       },
-      context: {
-        summary: 'TruthScope는 검증 가능한 사실 단위만 다룹니다.',
-        sourceCount: 0,
+      partialFailure: {
+        coverage: {
+          insufficientCount: 0,
+          timeSensitiveCount: 0,
+          outOfScopeCount: 0,
+          tier1Count: 3,
+          tier2Count: 2,
+          tier3Count: 0,
+        },
+        sourceTransparency: {
+          band: 'ALL_EXPLICIT',
+          explicitCount: 5,
+          ambiguousCount: 0,
+          noneCount: 0,
+        },
       },
+      context: { summary: '단일 출처 의존 baseline', sourceCount: 1 },
     },
   },
+};
+
+export const Skeleton: Story = {
+  args: { snapshot: undefined },
 };

--- a/src/04-widgets/result-card/ui/result-card.widget.tsx
+++ b/src/04-widgets/result-card/ui/result-card.widget.tsx
@@ -1,31 +1,47 @@
 'use client';
 
 import { cn } from '@/07-shared/lib/cn';
+import { ArticleFactScore } from '@04-widgets/article-fact-score';
+import { SiftMapping } from '@04-widgets/sift-mapping';
+import { PartialFailureDisplay } from '@04-widgets/partial-failure-display';
+import type { PartialFailureSnapshot } from '@04-widgets/partial-failure-display';
 import type { ResultCardSnapshot } from '@04-widgets/result-card/model/types';
 import { ContextSection } from '@04-widgets/result-card/ui/context-section';
 import { FactCheckSection } from '@04-widgets/result-card/ui/fact-check-section';
 
 interface Props {
-  /** Sprint 4 실 데이터 연동 전까지는 undefined 또는 부분 채워진 값 허용 (skeleton). */
+  /** Sprint 4 통합 시 ResultCardSnapshot 직접 주입. undefined 시 6 sub-component 자체 skeleton. */
   snapshot?: ResultCardSnapshot;
   className?: string;
 }
 
 export function ResultCard({ snapshot, className }: Props) {
+  // Q4 uniqueSourceCount fallback mapping (DISCUSS Q4 정합 — ContextSnapshot.sourceCount 재사용).
+  // useMemo 제거 (Round 1 CX-3 amend — 계산 싸고 deps shallow equality 함정 회피).
+  const mergedPartialFailure: PartialFailureSnapshot | undefined =
+    snapshot?.partialFailure
+      ? {
+          ...snapshot.partialFailure,
+          uniqueSourceCount:
+            snapshot.partialFailure.uniqueSourceCount ??
+            snapshot.context?.sourceCount,
+        }
+      : undefined;
+
   return (
     <article
       aria-label="분석 결과"
       className={cn(
-        'flex flex-col overflow-hidden rounded-2xl border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface-base)] ambient-shadow',
+        // ambient-shadow는 src/app/globals.css 정의 (tokens.css 미등재, Round 1 M-1 amend 주석).
+        // 외곽 padding 제거 (Round 1 CX-4 amend — 기존 FactCheckSection/ContextSection 자체 p-[var(--spacing-24)] 정합, 이중 padding 회피).
+        'flex flex-col gap-[var(--spacing-16)] overflow-hidden rounded-2xl border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface-base)] ambient-shadow',
         className
       )}
     >
+      <ArticleFactScore snapshot={snapshot?.articleFactScore} />
+      <SiftMapping snapshot={snapshot?.siftMapping} />
       <FactCheckSection snapshot={snapshot?.factCheck} />
-      <div
-        role="separator"
-        aria-orientation="horizontal"
-        className="h-px bg-[var(--color-border-subtle)]"
-      />
+      <PartialFailureDisplay snapshot={mergedPartialFailure} />
       <ContextSection snapshot={snapshot?.context} />
       <p className="px-[var(--spacing-24)] pb-[var(--spacing-16)] text-xs text-[var(--color-text-secondary)]">
         AI 분석이며 기관 검증이 아닙니다. 참고 용도로만 활용하세요.

--- a/src/04-widgets/sift-mapping/index.ts
+++ b/src/04-widgets/sift-mapping/index.ts
@@ -1,0 +1,5 @@
+export { SiftMapping } from './ui/sift-mapping';
+export type {
+  SiftMappingSnapshot,
+  SourceTransparencyBand,
+} from './model/types';

--- a/src/04-widgets/sift-mapping/model/types.ts
+++ b/src/04-widgets/sift-mapping/model/types.ts
@@ -1,0 +1,39 @@
+/**
+ * SIFT 4단계 매핑 widget 도메인 타입. ADR-020 정합.
+ *
+ * BE 매핑: core/.../scoring/{SourceTransparencyBand,SourceTransparencySummary}.java
+ * - SourceTransparencyBand: 3종 enum (ALL_EXPLICIT / SOME_UNCLEAR / MISSING_SOURCE).
+ * - SourceTransparencySummary: band + 3 count (explicit/ambiguous/none).
+ *
+ * SIFT 4단계 책임 분리:
+ * - S (Stop): 정적 안내 배지 (별도 데이터 없음).
+ * - I (Investigate): SourceTransparencySummary 매핑.
+ * - F (Find): cross-source 결과 (Tier 1/2 + adapter 다양성).
+ * - T (Trace): attribution 링크 list (ADR-020 결정 1).
+ *   - 시스템 자동 맥락 정확성 판정 금지 (ADR-020 결정 2).
+ */
+export type SourceTransparencyBand =
+  | 'ALL_EXPLICIT'
+  | 'SOME_UNCLEAR'
+  | 'MISSING_SOURCE';
+
+export interface SiftMappingSnapshot {
+  /** I: Investigate the source — BE SourceTransparencySummary 매핑. */
+  sourceTransparency?: {
+    band: SourceTransparencyBand;
+    explicitCount: number;
+    ambiguousCount: number;
+    noneCount: number;
+  };
+  /** F: Find better coverage — Tier 1/2 결과 + adapter 다양성. */
+  crossSource?: {
+    tier1Count: number;
+    tier2Count: number;
+    adapterDiversity: number;
+  };
+  /** T: Trace claims to origin — attribution 링크 list (ADR-020 결정 1). */
+  attributionLinks?: Array<{
+    url: string;
+    label: string;
+  }>;
+}

--- a/src/04-widgets/sift-mapping/ui/sift-mapping.stories.tsx
+++ b/src/04-widgets/sift-mapping/ui/sift-mapping.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { SiftMapping } from '@/04-widgets/sift-mapping';
+
+const meta = {
+  title: '04-widgets/SiftMapping',
+  component: SiftMapping,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof SiftMapping>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    snapshot: {
+      sourceTransparency: {
+        band: 'ALL_EXPLICIT',
+        explicitCount: 4,
+        ambiguousCount: 1,
+        noneCount: 0,
+      },
+      crossSource: { tier1Count: 3, tier2Count: 5, adapterDiversity: 4 },
+      attributionLinks: [
+        { url: 'https://kostat.go.kr', label: '통계청 공식 자료' },
+        { url: 'https://customs.go.kr', label: '관세청 수출입 통계' },
+      ],
+    },
+  },
+};
+
+export const AllExplicit: Story = {
+  args: {
+    snapshot: {
+      sourceTransparency: {
+        band: 'ALL_EXPLICIT',
+        explicitCount: 5,
+        ambiguousCount: 0,
+        noneCount: 0,
+      },
+      crossSource: { tier1Count: 4, tier2Count: 4, adapterDiversity: 5 },
+      attributionLinks: [
+        { url: 'https://kostat.go.kr', label: '통계청 1차 자료' },
+      ],
+    },
+  },
+};
+
+export const SomeUnclear: Story = {
+  args: {
+    snapshot: {
+      sourceTransparency: {
+        band: 'SOME_UNCLEAR',
+        explicitCount: 3,
+        ambiguousCount: 2,
+        noneCount: 0,
+      },
+      crossSource: { tier1Count: 2, tier2Count: 3, adapterDiversity: 3 },
+      attributionLinks: [],
+    },
+  },
+};
+
+export const MissingSource: Story = {
+  args: {
+    snapshot: {
+      sourceTransparency: {
+        band: 'MISSING_SOURCE',
+        explicitCount: 2,
+        ambiguousCount: 1,
+        noneCount: 2,
+      },
+      crossSource: { tier1Count: 1, tier2Count: 2, adapterDiversity: 2 },
+      attributionLinks: [],
+    },
+  },
+};
+
+export const TraceOnly: Story = {
+  args: {
+    snapshot: {
+      attributionLinks: [
+        { url: 'https://example.com/a', label: '원문 기사 A' },
+        { url: 'https://example.com/b', label: '원문 보고서 B' },
+        { url: 'https://example.com/c', label: '공식 데이터 C' },
+      ],
+    },
+  },
+};
+
+export const Skeleton: Story = {
+  args: { snapshot: undefined },
+};

--- a/src/04-widgets/sift-mapping/ui/sift-mapping.tsx
+++ b/src/04-widgets/sift-mapping/ui/sift-mapping.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import { useId } from 'react';
+import { cn } from '@/07-shared/lib/cn';
+import type {
+  SiftMappingSnapshot,
+  SourceTransparencyBand,
+} from '@04-widgets/sift-mapping/model/types';
+
+interface Props {
+  snapshot?: SiftMappingSnapshot;
+  className?: string;
+}
+
+const BAND_LABEL: Record<SourceTransparencyBand, string> = {
+  ALL_EXPLICIT: '모두 명시',
+  SOME_UNCLEAR: '일부 불명확',
+  MISSING_SOURCE: '출처 누락 있음',
+};
+
+const BAND_TONE: Record<SourceTransparencyBand, string> = {
+  ALL_EXPLICIT: 'text-[var(--color-success-strong)]',
+  SOME_UNCLEAR: 'text-[var(--color-info)]',
+  MISSING_SOURCE: 'text-[var(--color-error)]',
+};
+
+const TRACE_DISCLAIMER =
+  '원출처 링크를 사용자가 직접 확인하도록 표시합니다. 시스템이 맥락 정확성을 자동 판정하지 않습니다 (ADR-020).';
+
+export function SiftMapping({ snapshot, className }: Props) {
+  const titleId = useId();
+
+  if (!snapshot) {
+    return <SiftMappingSkeleton className={className} />;
+  }
+
+  const investigateText = snapshot.sourceTransparency
+    ? `${BAND_LABEL[snapshot.sourceTransparency.band]} · 명시 ${snapshot.sourceTransparency.explicitCount} · 불명확 ${snapshot.sourceTransparency.ambiguousCount} · 누락 ${snapshot.sourceTransparency.noneCount}`
+    : '출처 정보 없음';
+
+  const findText = snapshot.crossSource
+    ? `Tier 1 ${snapshot.crossSource.tier1Count}건 · Tier 2 ${snapshot.crossSource.tier2Count}건 · 출처 ${snapshot.crossSource.adapterDiversity}종`
+    : 'cross-source 정보 없음';
+
+  return (
+    <section
+      aria-labelledby={titleId}
+      className={cn(
+        'flex flex-col overflow-hidden rounded-lg border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface-base)]',
+        className
+      )}
+    >
+      <header className="flex items-center justify-between border-b border-[var(--color-border-subtle)] p-[var(--spacing-16)]">
+        <h3
+          id={titleId}
+          className="m-0 text-base font-semibold text-[var(--color-text-heading)]"
+        >
+          SIFT 4단계
+        </h3>
+        <span className="text-xs text-[var(--color-text-secondary)]">N-3</span>
+      </header>
+
+      <div className="flex flex-col">
+        <SiftRow
+          letter="S"
+          label="Stop"
+          description="제목과 감정적 표현을 분리해 읽기"
+        />
+        <SiftRow
+          letter="I"
+          label="Investigate"
+          description={investigateText}
+          band={snapshot.sourceTransparency?.band}
+        />
+        <SiftRow letter="F" label="Find" description={findText} />
+        <SiftRow
+          letter="T"
+          label="Trace"
+          description={TRACE_DISCLAIMER}
+          links={snapshot.attributionLinks}
+        />
+      </div>
+    </section>
+  );
+}
+
+interface SiftRowProps {
+  letter: 'S' | 'I' | 'F' | 'T';
+  label: string;
+  description: string;
+  band?: SourceTransparencyBand;
+  links?: Array<{ url: string; label: string }>;
+}
+
+function SiftRow({ letter, label, description, band, links }: SiftRowProps) {
+  const isLast = letter === 'T';
+  return (
+    <div
+      className={cn(
+        'grid grid-cols-[36px_minmax(0,1fr)] items-start gap-[var(--spacing-10)] p-[var(--spacing-16)]',
+        !isLast && 'border-b border-[var(--color-border-subtle)]'
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface-base)] text-sm font-semibold text-[var(--color-brand-primary)]"
+      >
+        {letter}
+      </span>
+      <div className="flex flex-col gap-[var(--spacing-6)]">
+        <strong className="text-sm font-semibold text-[var(--color-text-primary)]">
+          {label}
+        </strong>
+        <span
+          className={cn(
+            'text-xs leading-relaxed text-[var(--color-text-secondary)]',
+            band && BAND_TONE[band]
+          )}
+        >
+          {description}
+        </span>
+        {links !== undefined && <SiftAttributionLinks links={links} />}
+      </div>
+    </div>
+  );
+}
+
+function SiftAttributionLinks({
+  links,
+}: {
+  links: Array<{ url: string; label: string }>;
+}) {
+  if (links.length === 0) {
+    return (
+      <span className="text-xs text-[var(--color-text-secondary)]">
+        원출처 추적 가능 링크 없음
+      </span>
+    );
+  }
+  return (
+    <ul className="m-0 flex list-none flex-col gap-[var(--spacing-6)] p-0">
+      {links.map((link, idx) => (
+        <li key={idx}>
+          <a
+            href={link.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-[var(--color-brand-primary)] underline underline-offset-2"
+          >
+            {link.label}
+          </a>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function SiftMappingSkeleton({ className }: { className?: string }) {
+  return (
+    <section
+      aria-hidden="true"
+      className={cn(
+        'flex flex-col overflow-hidden rounded-lg border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface-base)]',
+        className
+      )}
+    >
+      <div className="border-b border-[var(--color-border-subtle)] p-[var(--spacing-16)]">
+        <span className="block h-4 w-[140px] animate-pulse rounded bg-[var(--color-bg-surface-sunken)]" />
+      </div>
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div
+          key={i}
+          className="grid grid-cols-[36px_minmax(0,1fr)] gap-[var(--spacing-10)] border-b border-[var(--color-border-subtle)] p-[var(--spacing-16)] last:border-b-0"
+        >
+          <span className="h-7 w-7 animate-pulse rounded-full bg-[var(--color-bg-surface-sunken)]" />
+          <div className="flex flex-col gap-[var(--spacing-6)]">
+            <span className="block h-3 w-[80px] animate-pulse rounded bg-[var(--color-bg-surface-sunken)]" />
+            <span className="block h-3 w-[200px] animate-pulse rounded bg-[var(--color-bg-surface-sunken)]" />
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}


### PR DESCRIPTION
<!-- SAFE_OP_START -->
Assumptions: phase 57~60 result-card 통합 작업(feat/verdict-truth-label-fix, 미머지)을 현 dev로 cherry-pick 정렬. BE API는 Storybook mock 유지(실 연동은 #46-followup).
Scope: src/04-widgets/{article-fact-score,sift-mapping,partial-failure-display}/ (신규) + src/04-widgets/result-card/{model/types.ts,ui/result-card.widget.tsx,ui/result-card.stories.tsx} (수정)
Out-of-scope: BE 실 연동/ResultCard caller wiring (#46-followup), FreshnessBadge wire (Phase 64), 데스크탑 2-column layout
<!-- SAFE_OP_END -->

## Done

- [x] **요구사항**: ResultCard에 ArticleFactScore + SiftMapping + PartialFailureDisplay 3 sub-component 조립 (6 섹션 수직 stack). 각 widget standalone + Storybook.
- [x] **산출물**: 신규 widget 3종(article-fact-score/sift-mapping/partial-failure-display) + result-card 통합 3파일 수정. cherry-pick c6a447f/d5c9ec1/174b8aa/76945be.
- [x] **수용 테스트**: typecheck 0 + lint 0 + stylelint 0 + vitest 99 passed + build 7 라우트. (plan-review-deep Round 1+2 18 amend는 원 phase 60에서 수렴)

## Behavior Gates 자체 점검
- [x] Gate 1 — Goal Defined
- [x] Gate 2 — Assumption Surfaced (SAFE_OP)
- [x] Gate 3 — Surgical Diff (result-card 통합 + 3 widget만)
- [x] Gate 4 — Minimum Code

## 변경 사항

phase 57~60 result-card 통합을 현 dev 기준으로 cherry-pick 정렬하여 dev에 반영. 기존 `feat/verdict-truth-label-fix`는 BYOK #47 이전 베이스라 미머지 상태였음 — 현 dev 위로 4 atomic commit cherry-pick (충돌 0, CRLF 노이즈만 해소).

- ArticleFactScore: 검증 가능 주장 기준 종합 점수 표시
- SiftMapping: SIFT 4 mini-row + ADR-020 disclaimer
- PartialFailureDisplay: 부분 실패 사유 + 절충안 A' (uniqueSourceCount optional)
- ResultCard: 6 섹션 수직 stack 조립 + Storybook 6 케이스

원 작업 상세: `.plans/60-fe46-result-card-integration-2026-05-28/` (plan-review-deep Round 1+2, WCAG 10.88:1 AAA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 검증된 주장 점수를 표시하는 기사 팩트 점수 위젯 추가
  * 부분 실패 및 출처 투명성 정보를 표시하는 위젯 추가
  * SIFT 4단계 검증 과정을 시각화하는 위젯 추가
  * 결과 카드에 새로운 검증 정보 섹션 통합

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/truthscope-smu/truthscope-web-frontend/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->