### PR TITLE
✨feat(result-card): claim 인용 표기 UI + disclaimer (FE #49)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,25 @@ jobs:
           retention-days: 14
           if-no-files-found: warn
 
+      # ── FSD 아키텍처 + 네이밍 + 캐시 정책 검증 ──
+
+      - name: Arch (dependency-cruiser FSD 검증)
+        run: npm run arch
+
+      - name: Check file names
+        run: npm run check:names
+
+      - name: Check cache config
+        run: npm run check:cache
+
+      # ── 브라우저 테스트 (UI + a11y) ──
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Browser tests (UI + a11y)
+        run: npm run test:browser
+
       # ── 빌드 ──
 
       - name: Build Project

--- a/scripts/check-file-names.mjs
+++ b/scripts/check-file-names.mjs
@@ -8,8 +8,9 @@ import { join } from 'node:path';
 
 const ROOT = 'src';
 // rev.1 CX1-06 fix: dot-role suffix (.widget, .component, .hook) 허용 추가
+// phase 63 fix: CSS Module 표준 컨벤션 .module.css만 허용 (.module은 .css에만 결합 — .module.ts/.tsx 차단).
 const ALLOWED =
-  /^([a-z0-9]+(-[a-z0-9]+)*|\[[^\]]+\])(\.(test|stories|d|spec|widget|component|hook|context|api|schema))?\.(ts|tsx|css)$/;
+  /^([a-z0-9]+(-[a-z0-9]+)*|\[[^\]]+\])(\.module\.css|(\.(test|stories|d|spec|widget|component|hook|context|api|schema))?\.(ts|tsx|css))$/;
 const SKIP_DIRS = new Set(['node_modules', '.next', 'coverage']);
 
 let violations = 0;

--- a/src/04-widgets/result-card/index.ts
+++ b/src/04-widgets/result-card/index.ts
@@ -6,4 +6,5 @@ export type {
   RelatedArticleRef,
   TruthLabel,
   ClaimScoreStatus,
+  ClaimAttributionSnapshot,
 } from './model/types';

--- a/src/04-widgets/result-card/model/types.ts
+++ b/src/04-widgets/result-card/model/types.ts
@@ -57,6 +57,22 @@ export interface ContextSnapshot {
   sourceCount?: number;
 }
 
+/**
+ * Claim 인용 표기 sub-component (#49 phase 63) — attribution 보존 (M-3, FM12).
+ * BE 매핑 예정: claims.is_quoted_claim / speaker_name / original_context (S3-09 BE #76, 별 phase).
+ * isQuotedClaim true일 때만 화자 귀속 표기 + disclaimer 노출.
+ */
+export interface ClaimAttributionSnapshot {
+  /** 인용 주장 여부. true면 화자 귀속 표기 + disclaimer. */
+  isQuotedClaim: boolean;
+  /** 주장 본문. 없거나 빈 문자열이면 skeleton. */
+  claimText?: string;
+  /** 화자 또는 주체명. isQuotedClaim일 때만 의미. 없으면 "인용된 주장" 폴백. */
+  speakerName?: string;
+  /** 인용 원문 맥락. details 펼치기로 노출 (선택). */
+  originalContext?: string;
+}
+
 export interface ResultCardSnapshot {
   /**
    * N-1 sub-component (#41 phase 57 DONE) — 기사 종합 점수.
@@ -72,6 +88,8 @@ export interface ResultCardSnapshot {
    * scorableCount/excludedCount는 derive 가능하므로 widget 노출 제외.
    */
   partialFailure?: PartialFailureSnapshot;
+  /** claim 인용 표기 sub-component (#49 phase 63) — attribution + disclaimer. */
+  claimAttribution?: ClaimAttributionSnapshot;
   /** 기존 — claim별 진실성 라벨. */
   factCheck?: FactCheckSnapshot;
   /** 기존 — 맥락 (요약 + 관련 기사 + sourceCount). */

--- a/src/04-widgets/result-card/ui/claim-attribution-section.test.tsx
+++ b/src/04-widgets/result-card/ui/claim-attribution-section.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { ClaimAttributionSection } from '@04-widgets/result-card/ui/claim-attribution-section';
+
+afterEach(cleanup);
+
+describe('ClaimAttributionSection — quoted claim', () => {
+  it('shows speaker badge, disclaimer(role=note), and details when quoted with context', () => {
+    render(
+      <ClaimAttributionSection
+        snapshot={{
+          isQuotedClaim: true,
+          speakerName: '김OO',
+          claimText: '주장 본문',
+          originalContext: '원문 맥락',
+        }}
+      />
+    );
+    expect(screen.getByLabelText('화자: 김OO')).toBeDefined();
+    const note = screen.getByRole('note');
+    expect(note.textContent).toContain('화자의 입장이며');
+    expect(screen.getByText('원문 맥락 보기')).toBeDefined();
+  });
+});
+
+describe('ClaimAttributionSection — non-quoted', () => {
+  it('renders claimText only, no disclaimer, no badge', () => {
+    render(
+      <ClaimAttributionSection
+        snapshot={{ isQuotedClaim: false, claimText: '비인용 주장' }}
+      />
+    );
+    expect(screen.getByText('비인용 주장')).toBeDefined();
+    expect(screen.queryByRole('note')).toBeNull();
+  });
+});
+
+describe('ClaimAttributionSection — skeleton', () => {
+  it('renders skeleton when snapshot undefined', () => {
+    const { container } = render(<ClaimAttributionSection />);
+    expect(container.querySelector('[class*="animate-pulse"]')).not.toBeNull();
+    expect(screen.queryByRole('note')).toBeNull();
+  });
+});
+
+// C2 — quoted edge 계약 방어
+describe('ClaimAttributionSection — quoted edge', () => {
+  it('quoted without speakerName falls back to "인용된 주장" aria-label', () => {
+    render(
+      <ClaimAttributionSection
+        snapshot={{ isQuotedClaim: true, claimText: '주장' }}
+      />
+    );
+    expect(screen.getByLabelText('인용된 주장')).toBeDefined();
+    // disclaimer는 화자명 없어도 노출
+    expect(screen.getByRole('note')).toBeDefined();
+  });
+
+  it('quoted without originalContext renders no details toggle', () => {
+    render(
+      <ClaimAttributionSection
+        snapshot={{
+          isQuotedClaim: true,
+          speakerName: '김OO',
+          claimText: '주장',
+        }}
+      />
+    );
+    expect(screen.queryByText('원문 맥락 보기')).toBeNull();
+  });
+
+  it('quoted with empty claimText shows skeleton (note still present)', () => {
+    const { container } = render(
+      <ClaimAttributionSection
+        snapshot={{ isQuotedClaim: true, speakerName: '김OO', claimText: '' }}
+      />
+    );
+    expect(container.querySelector('[class*="animate-pulse"]')).not.toBeNull();
+    expect(screen.getByRole('note')).toBeDefined();
+  });
+});

--- a/src/04-widgets/result-card/ui/claim-attribution-section.tsx
+++ b/src/04-widgets/result-card/ui/claim-attribution-section.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useId } from 'react';
+import { cn } from '@/07-shared/lib/cn';
+import type { ClaimAttributionSnapshot } from '@04-widgets/result-card/model/types';
+
+interface Props {
+  snapshot?: ClaimAttributionSnapshot;
+  className?: string;
+}
+
+// DISCUSS Q1 C1 확정 문구 — 임의 의역 금지.
+const ATTRIBUTION_DISCLAIMER =
+  '인용된 주장은 화자의 입장이며, 사실로 확인된 내용이 아닙니다.';
+
+export function ClaimAttributionSection({ snapshot, className }: Props) {
+  const titleId = useId();
+
+  return (
+    <section
+      aria-labelledby={titleId}
+      className={cn(
+        'flex flex-col gap-[var(--spacing-16)] p-[var(--spacing-24)]',
+        className
+      )}
+    >
+      <header className="flex items-center justify-between gap-[var(--spacing-16)]">
+        <h3
+          id={titleId}
+          className="text-[var(--color-text-heading)] text-lg font-semibold"
+        >
+          인용 표기
+        </h3>
+        {snapshot?.isQuotedClaim && (
+          <span
+            aria-label={
+              snapshot.speakerName
+                ? `화자: ${snapshot.speakerName}`
+                : '인용된 주장'
+            }
+            className="inline-flex items-center gap-[var(--spacing-6)] rounded-full bg-brand-subtle px-[var(--spacing-10)] py-[var(--spacing-6)] text-xs font-medium text-brand-primary"
+          >
+            <span aria-hidden="true">“ ”</span>
+            {snapshot.speakerName ?? '인용'}
+          </span>
+        )}
+      </header>
+
+      {/* 주장 본문 */}
+      {snapshot?.claimText ? (
+        <p className="text-[var(--color-text-primary)] text-base leading-relaxed">
+          {snapshot.isQuotedClaim && (
+            <span className="text-[var(--color-text-secondary)] text-sm">
+              {snapshot.speakerName ? `${snapshot.speakerName} · ` : ''}주장
+              인용{' '}
+            </span>
+          )}
+          {snapshot.claimText}
+        </p>
+      ) : (
+        // snapshot undefined 또는 claimText 부재(빈 문자열 포함) 둘 다 skeleton.
+        // sibling(fact-check-section, context-section) binary 분기 패턴 정합.
+        <SkeletonLines lines={2} />
+      )}
+
+      {/* disclaimer — 인용 주장에만 (implied-truth 대칭성, DISCUSS Q1) */}
+      {snapshot?.isQuotedClaim && (
+        <p
+          role="note"
+          className="flex items-start gap-[var(--spacing-8)] rounded-md border-l-2 border-[var(--color-info)] bg-[var(--color-blue-50)] p-[var(--spacing-10)] text-sm text-[var(--color-text-primary)]"
+        >
+          <span aria-hidden="true">ℹ</span>
+          {ATTRIBUTION_DISCLAIMER}
+        </p>
+      )}
+
+      {/* 원문 맥락 펼치기 */}
+      {snapshot?.isQuotedClaim && snapshot.originalContext && (
+        <details className="rounded-md border border-[var(--color-border-subtle)] p-[var(--spacing-10)]">
+          <summary className="cursor-pointer text-sm font-medium text-[var(--color-text-accent)]">
+            원문 맥락 보기
+          </summary>
+          <p className="mt-[var(--spacing-8)] text-sm leading-relaxed text-[var(--color-text-secondary)]">
+            {snapshot.originalContext}
+          </p>
+        </details>
+      )}
+    </section>
+  );
+}
+
+function SkeletonLines({ lines }: { lines: number }) {
+  return (
+    <div aria-hidden="true" className="flex flex-col gap-[var(--spacing-8)]">
+      {Array.from({ length: lines }).map((_, i) => (
+        <span
+          key={i}
+          className="block h-3 animate-pulse rounded bg-[var(--color-bg-surface-sunken)]"
+          style={{ width: `${100 - i * 12}%` }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/04-widgets/result-card/ui/result-card-integration.test.tsx
+++ b/src/04-widgets/result-card/ui/result-card-integration.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { ResultCard } from '@/04-widgets/result-card';
+
+afterEach(cleanup);
+
+// 회귀 시뮬레이션 C (widget wire 제거)를 executable하게 만드는 통합 테스트.
+describe('ResultCard — claim attribution integration', () => {
+  it('renders ClaimAttributionSection (인용 표기 heading + note) when claimAttribution provided', () => {
+    render(
+      <ResultCard
+        snapshot={{
+          claimAttribution: {
+            isQuotedClaim: true,
+            speakerName: '김OO',
+            claimText: '주장 본문',
+          },
+        }}
+      />
+    );
+    expect(screen.getByRole('heading', { name: '인용 표기' })).toBeDefined();
+    expect(screen.getByRole('note').textContent).toContain('화자의 입장이며');
+  });
+});

--- a/src/04-widgets/result-card/ui/result-card.stories.tsx
+++ b/src/04-widgets/result-card/ui/result-card.stories.tsx
@@ -32,6 +32,13 @@ export const NormalScore: Story = {
           { url: 'https://kostat.go.kr', label: '통계청 자료' },
         ],
       },
+      claimAttribution: {
+        isQuotedClaim: true,
+        speakerName: '김OO',
+        claimText: '내년 물가상승률은 2퍼센트대로 안정될 것',
+        originalContext:
+          '브리핑에서 "내년 물가상승률은 2퍼센트대로 안정될 것"이라고 밝혔다.',
+      },
       factCheck: {
         truthLabel: 'FACT',
         confidence: 90,
@@ -74,6 +81,10 @@ export const ZeroFloor: Story = {
           ambiguousCount: 2,
           noneCount: 5,
         },
+      },
+      claimAttribution: {
+        isQuotedClaim: false,
+        claimText: '비인용 — 기사 본문이 직접 단정한 주장',
       },
       factCheck: {
         truthLabel: 'NOT_FACT',

--- a/src/04-widgets/result-card/ui/result-card.widget.tsx
+++ b/src/04-widgets/result-card/ui/result-card.widget.tsx
@@ -6,6 +6,7 @@ import { SiftMapping } from '@04-widgets/sift-mapping';
 import { PartialFailureDisplay } from '@04-widgets/partial-failure-display';
 import type { PartialFailureSnapshot } from '@04-widgets/partial-failure-display';
 import type { ResultCardSnapshot } from '@04-widgets/result-card/model/types';
+import { ClaimAttributionSection } from '@04-widgets/result-card/ui/claim-attribution-section';
 import { ContextSection } from '@04-widgets/result-card/ui/context-section';
 import { FactCheckSection } from '@04-widgets/result-card/ui/fact-check-section';
 
@@ -40,6 +41,7 @@ export function ResultCard({ snapshot, className }: Props) {
     >
       <ArticleFactScore snapshot={snapshot?.articleFactScore} />
       <SiftMapping snapshot={snapshot?.siftMapping} />
+      <ClaimAttributionSection snapshot={snapshot?.claimAttribution} />
       <FactCheckSection snapshot={snapshot?.factCheck} />
       <PartialFailureDisplay snapshot={mergedPartialFailure} />
       <ContextSection snapshot={snapshot?.context} />


### PR DESCRIPTION
## 요약

result-card에 claim 인용 표기 sub-section 추가. 인용 주장은 화자 귀속 표기 + 전용 disclaimer, 비인용은 본문만 표시. originalContext는 details 펼치기. (S3-11, S3-09 짝)

Closes #49

<!-- SAFE_OP_START -->
Assumptions: BE S3-09(#76) 미업로드 — FE 정의 optional snapshot으로 진행, 실연동은 별 phase
Scope: src/04-widgets/result-card/** (types, claim-attribution-section, widget wire, barrel, stories, test 2종), .github/workflows/ci.yml, scripts/check-file-names.mjs
Out-of-scope: BE attribution 자동 추출, /analysis/[id] 라우트 E2E
<!-- SAFE_OP_END -->

## Done

- [x] `claim-attribution-section.tsx` — isQuotedClaim 분기 + 화자 귀속 + disclaimer + originalContext details 펼치기
- [x] `ResultCardSnapshot.claimAttribution` + barrel export (camelCase, ADR-014)
- [x] SiftMapping 다음 / FactCheck 앞 wire
- [x] browser 테스트 7건 + ResultCard 통합 테스트 1건 (총 10/10 PASS)
- [x] CI: test:browser + arch + check:names + check:cache 편입 (.module.css allowlist 보강)
- [x] 회귀 시뮬레이션 ABC (분기/콘텐츠/통합 3계층 무력화 검증)
- 수용 테스트: Vitest browser (role=note/aria-label/details/통합) + typecheck/lint/arch/build GREEN

## 검증

- typecheck · lint · arch · check:names · check:cache PASS / test:browser 10/10 / build 7라우트
- plan-review-deep R1 (Opus + codex gpt-5.5 Contract Lens, Critical 0) + execute 4th lens (Critical/High 0)
- disclaimer 문구는 implied-truth effect(Pennycook 2020, Management Science) + negativity bias(Stein & Meyersohn 2025, Communication Research) 근거로 중립 epistemic distancing 채택 (경고 톤 회피)

## a11y

- role=note disclaimer, 화자 aria-label, 네이티브 details(키보드/스크린리더), 색 단독 의존 금지(WCAG 1.4.1: border + ℹ 아이콘 + 텍스트)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 검색 결과 카드에 인용 표기 기능 추가 (화자 정보, 주장 텍스트, 원문 맥락 표시)

* **Tests**
  * 브라우저 기반 UI 및 접근성 테스트 단계 CI 파이프라인에 통합
  * 인용 표기 컴포넌트 및 결과 카드 통합 테스트 케이스 추가

* **Chores**
  * 파일명 검증 규칙 강화 (CSS 모듈 네이밍 규칙 정규화)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/truthscope-smu/truthscope-web-frontend/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->