### PR TITLE
✨feat(result-card): FreshnessBadge 결과 카드 wire + 아이콘 제거·라벨 개선

### DIFF
--- a/src/04-widgets/freshness-badge/lib/badge-config.ts
+++ b/src/04-widgets/freshness-badge/lib/badge-config.ts
@@ -2,7 +2,6 @@ import type { StalenessHint } from '@04-widgets/freshness-badge/model/types';
 
 export interface BadgeVisual {
   label: string;
-  icon: string;
   className: string;
   ariaPrefix: string;
 }
@@ -10,32 +9,27 @@ export interface BadgeVisual {
 export const BADGE_CONFIG: Record<StalenessHint, BadgeVisual> = {
   fresh: {
     label: '최신',
-    icon: '✓',
     className: 'badge-fresh',
     ariaPrefix: '검증 최신',
   },
   stable: {
-    label: '안정',
-    icon: '◐',
+    label: '양호',
     className: 'badge-stable',
-    ariaPrefix: '검증 안정',
+    ariaPrefix: '검증 양호',
   },
   aging: {
-    label: '노후화',
-    icon: '◑',
+    label: '재확인 권장',
     className: 'badge-aging',
-    ariaPrefix: '검증 노후화',
+    ariaPrefix: '검증 재확인 권장',
   },
   stale: {
-    label: '노후',
-    icon: '◓',
+    label: '오래됨',
     className: 'badge-stale',
-    ariaPrefix: '검증 노후',
+    ariaPrefix: '검증 오래됨',
   },
   expired: {
-    label: '만료',
-    icon: '⚠',
+    label: '기한 지남',
     className: 'badge-expired',
-    ariaPrefix: '검증 만료',
+    ariaPrefix: '검증 기한 지남',
   },
 };

--- a/src/04-widgets/freshness-badge/ui/freshness-badge.module.css
+++ b/src/04-widgets/freshness-badge/ui/freshness-badge.module.css
@@ -11,10 +11,6 @@
   white-space: nowrap;
 }
 
-.icon {
-  line-height: 1;
-}
-
 .label {
   font-weight: 600;
 }
@@ -32,17 +28,9 @@
   border-left-color: var(--color-success-strong);
 }
 
-.badge-fresh .icon {
-  color: var(--color-success-strong);
-}
-
 .badge-stable {
   background: var(--color-bg-surface-raised);
   border-left-color: var(--color-brand-secondary);
-}
-
-.badge-stable .icon {
-  color: var(--color-brand-secondary);
 }
 
 .badge-aging {
@@ -50,26 +38,14 @@
   border-left-color: var(--color-aging-strong);
 }
 
-.badge-aging .icon {
-  color: var(--color-aging-strong);
-}
-
 .badge-stale {
   background: var(--color-warning-subtle);
   border-left-color: var(--color-warning-strong);
 }
 
-.badge-stale .icon {
-  color: var(--color-warning-strong);
-}
-
 .badge-expired {
   background: var(--color-error-subtle);
   border-left-color: var(--color-error);
-}
-
-.badge-expired .icon {
-  color: var(--color-error);
 }
 
 .skeleton {

--- a/src/04-widgets/freshness-badge/ui/freshness-badge.test.tsx
+++ b/src/04-widgets/freshness-badge/ui/freshness-badge.test.tsx
@@ -6,8 +6,9 @@ afterEach(cleanup);
 
 // Fixed timestamps for deterministic hint computation (no wall-clock dependency)
 const NOW = 1_000_000_000_000;
-const THIRTY_MIN_AGO = NOW - 30 * 60 * 1000; // fresh
-const TWO_DAYS_AGO = NOW - 2 * 24 * 60 * 60 * 1000; // aging
+const THIRTY_MIN_AGO = NOW - 30 * 60 * 1000; // fresh (<=1h)
+const TWELVE_HOURS_AGO = NOW - 12 * 60 * 60 * 1000; // stable (>1h, <=1day)
+const TWO_DAYS_AGO = NOW - 2 * 24 * 60 * 60 * 1000; // aging (>1day, <=3day)
 
 describe('FreshnessBadge — hint label after mount', () => {
   it('shows "최신" label for a fresh createdAtMs+nowMs pair', async () => {
@@ -36,6 +37,17 @@ describe('FreshnessBadge — role=status aria-label', () => {
   });
 });
 
+describe('FreshnessBadge — stable label (검증 양호)', () => {
+  it('stable 상태는 aria-label에 검증 양호를 포함', async () => {
+    render(<FreshnessBadge createdAtMs={TWELVE_HOURS_AGO} nowMs={NOW} />);
+    await waitFor(() => {
+      const badge = screen.getAllByRole('status')[0]!;
+      const ariaLabel = badge.getAttribute('aria-label') ?? '';
+      expect(ariaLabel).toContain('검증 양호');
+    });
+  });
+});
+
 describe('FreshnessBadge — skeleton-to-badge transition', () => {
   it('renders role=status badge with correct label after effect and shows no skeleton', async () => {
     const { container } = render(
@@ -50,11 +62,11 @@ describe('FreshnessBadge — skeleton-to-badge transition', () => {
       expect(screen.getAllByRole('status').length).toBeGreaterThan(0);
     });
 
-    // Badge for aging should show "노후화"
+    // Badge for aging should show "재확인 권장"
     await waitFor(() => {
       const badge = screen.getAllByRole('status')[0]!;
       const ariaLabel = badge.getAttribute('aria-label') ?? '';
-      expect(ariaLabel).toContain('검증 노후화');
+      expect(ariaLabel).toContain('검증 재확인 권장');
     });
 
     // BadgeSkeleton (aria-hidden span with class skeleton) is NOT present once badge shows

--- a/src/04-widgets/freshness-badge/ui/freshness-badge.tsx
+++ b/src/04-widgets/freshness-badge/ui/freshness-badge.tsx
@@ -29,9 +29,6 @@ export function FreshnessBadge({ createdAtMs, nowMs }: FreshnessBadgeProps) {
       aria-label={`${v.ariaPrefix} · ${relative}`}
       className={`${styles.badge} ${styles[v.className]}`}
     >
-      <span aria-hidden="true" className={styles.icon}>
-        {v.icon}
-      </span>
       <span className={styles.label}>{v.label}</span>
       <span aria-hidden="true" className={styles.dot}>
         ·

--- a/src/04-widgets/result-card/index.ts
+++ b/src/04-widgets/result-card/index.ts
@@ -1,4 +1,5 @@
 export { ResultCard } from './ui/result-card.widget';
+export { freshnessSnapshotFromIso } from './lib/freshness';
 export type {
   ResultCardSnapshot,
   FactCheckSnapshot,
@@ -7,4 +8,5 @@ export type {
   TruthLabel,
   ClaimScoreStatus,
   ClaimAttributionSnapshot,
+  FreshnessSnapshot,
 } from './model/types';

--- a/src/04-widgets/result-card/lib/freshness.test.ts
+++ b/src/04-widgets/result-card/lib/freshness.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { freshnessSnapshotFromIso } from '@04-widgets/result-card/lib/freshness';
+
+describe('freshnessSnapshotFromIso', () => {
+  it('유효 ISO 문자열을 createdAtMs로 변환', () => {
+    const iso = '2026-05-30T00:00:00.000Z';
+    expect(freshnessSnapshotFromIso(iso)).toEqual({
+      createdAtMs: Date.parse(iso),
+    });
+  });
+
+  it('잘못된 문자열은 undefined (NaN 가드)', () => {
+    expect(freshnessSnapshotFromIso('not-a-date')).toBeUndefined();
+    expect(freshnessSnapshotFromIso('')).toBeUndefined();
+  });
+});

--- a/src/04-widgets/result-card/lib/freshness.ts
+++ b/src/04-widgets/result-card/lib/freshness.ts
@@ -1,0 +1,14 @@
+import type { FreshnessSnapshot } from '@04-widgets/result-card/model/types';
+
+/**
+ * ISO 문자열을 FreshnessSnapshot으로 변환. 임시 프록시 — article.createdAt(추출 시각)을
+ * 검증 시각 근사로 사용. BE verification_results.verified_at(#76) 랜딩 시 교체.
+ * 파싱 실패(NaN) 시 undefined 반환(배지 미렌더).
+ */
+export function freshnessSnapshotFromIso(
+  iso: string
+): FreshnessSnapshot | undefined {
+  const createdAtMs = Date.parse(iso);
+  if (Number.isNaN(createdAtMs)) return undefined;
+  return { createdAtMs };
+}

--- a/src/04-widgets/result-card/model/types.ts
+++ b/src/04-widgets/result-card/model/types.ts
@@ -73,6 +73,17 @@ export interface ClaimAttributionSnapshot {
   originalContext?: string;
 }
 
+/**
+ * 검증 노후도 sub-component(#48 phase 62 widget, phase 64 wire).
+ */
+export interface FreshnessSnapshot {
+  /**
+   * 검증 시각(epoch ms). FreshnessBadge createdAtMs 입력.
+   * 현재 임시로 article 추출 시각(createdAt) 프록시. BE verification_results.verified_at(#76) 랜딩 시 교체.
+   */
+  createdAtMs: number;
+}
+
 export interface ResultCardSnapshot {
   /**
    * N-1 sub-component (#41 phase 57 DONE) — 기사 종합 점수.
@@ -90,6 +101,11 @@ export interface ResultCardSnapshot {
   partialFailure?: PartialFailureSnapshot;
   /** claim 인용 표기 sub-component (#49 phase 63) — attribution + disclaimer. */
   claimAttribution?: ClaimAttributionSnapshot;
+  /**
+   * 검증 노후도(#48). 임시 프록시 article.createdAt 사용,
+   * BE verification_results.verified_at(#76) 랜딩 시 교체.
+   */
+  freshness?: FreshnessSnapshot;
   /** 기존 — claim별 진실성 라벨. */
   factCheck?: FactCheckSnapshot;
   /** 기존 — 맥락 (요약 + 관련 기사 + sourceCount). */

--- a/src/04-widgets/result-card/ui/result-card-integration.test.tsx
+++ b/src/04-widgets/result-card/ui/result-card-integration.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
 import { ResultCard } from '@/04-widgets/result-card';
 
 afterEach(cleanup);
@@ -20,5 +20,33 @@ describe('ResultCard — claim attribution integration', () => {
     );
     expect(screen.getByRole('heading', { name: '인용 표기' })).toBeDefined();
     expect(screen.getByRole('note').textContent).toContain('화자의 입장이며');
+  });
+});
+
+// 회귀 시뮬레이션 A (freshness 렌더 게이팅) executable 통합 테스트.
+describe('ResultCard — freshness badge integration', () => {
+  it('freshness 제공 시 FreshnessBadge가 카드 최상단에 role=status로 렌더', async () => {
+    const NOW = 1_000_000_000_000; // 고정 epoch. hint 라벨엔 단언 안 함(wall-clock 비의존)
+    const { container } = render(
+      <ResultCard
+        snapshot={{ freshness: { createdAtMs: NOW - 30 * 60 * 1000 } }}
+      />
+    );
+    await waitFor(() => {
+      expect(screen.getAllByRole('status').length).toBeGreaterThan(0);
+    });
+    // 최상단 배치: article의 첫 자식 안에 role=status 배지가 있어야 함
+    const article = container.querySelector('article');
+    const firstChild = article?.firstElementChild;
+    expect(firstChild?.querySelector('[role="status"]')).not.toBeNull();
+    // 아이콘 제거: .icon class span 부재
+    expect(container.querySelector('[class*="icon"]')).toBeNull();
+  });
+
+  it('freshness 미제공 시 freshness 배지 미렌더', () => {
+    const { container } = render(
+      <ResultCard snapshot={{ factCheck: { claim: 'x' } }} />
+    );
+    expect(container.querySelector('[role="status"]')).toBeNull();
   });
 });

--- a/src/04-widgets/result-card/ui/result-card.widget.tsx
+++ b/src/04-widgets/result-card/ui/result-card.widget.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from '@/07-shared/lib/cn';
 import { ArticleFactScore } from '@04-widgets/article-fact-score';
+import { FreshnessBadge } from '@04-widgets/freshness-badge';
 import { SiftMapping } from '@04-widgets/sift-mapping';
 import { PartialFailureDisplay } from '@04-widgets/partial-failure-display';
 import type { PartialFailureSnapshot } from '@04-widgets/partial-failure-display';
@@ -39,6 +40,11 @@ export function ResultCard({ snapshot, className }: Props) {
         className
       )}
     >
+      {snapshot?.freshness && (
+        <div className="flex justify-end px-[var(--spacing-24)] pt-[var(--spacing-16)]">
+          <FreshnessBadge createdAtMs={snapshot.freshness.createdAtMs} />
+        </div>
+      )}
       <ArticleFactScore snapshot={snapshot?.articleFactScore} />
       <SiftMapping snapshot={snapshot?.siftMapping} />
       <ClaimAttributionSection snapshot={snapshot?.claimAttribution} />

--- a/src/app/analysis/[id]/page.tsx
+++ b/src/app/analysis/[id]/page.tsx
@@ -2,7 +2,11 @@
 
 import Link from 'next/link';
 import { useArticle } from '@/app/providers/article.context';
-import { ResultCard, type ResultCardSnapshot } from '@/04-widgets/result-card';
+import {
+  ResultCard,
+  type ResultCardSnapshot,
+  freshnessSnapshotFromIso,
+} from '@/04-widgets/result-card';
 import { AttachToSessionButton } from '@/05-features/attach-to-session';
 
 export default function AnalysisDetailPage() {
@@ -28,6 +32,9 @@ export default function AnalysisDetailPage() {
   // 또는 status(3종)와 confidence/evidence가 채워지는 매핑으로 교체된다.
   const cardSnapshot: ResultCardSnapshot | undefined = snapshot
     ? {
+        // 임시 프록시 — article 추출 시각(createdAt)을 검증 시각 근사로 사용.
+        // BE verification_results.verified_at(#76) 랜딩 시 교체.
+        freshness: freshnessSnapshotFromIso(snapshot.createdAt),
         factCheck: {
           claim: snapshot.title,
         },


### PR DESCRIPTION
## 요약
phase 62에서 standalone widget이던 FreshnessBadge(#48)를 결과 카드 최상단에 wire. 동시에 NN/g + 토스 UX 라이팅 근거로 배지 아이콘을 제거(라벨만)하고 라벨을 개선.

<!-- SAFE_OP_START -->
Assumptions: BE verification_results.verified_at 미배선이라 article.createdAt 임시 프록시 유효. 5-bucket 단계 수는 Phase 64 팀원 와이어프레임 리뷰로 검증.
Scope: src/04-widgets/result-card/{model,lib,ui,index}, src/04-widgets/freshness-badge/{lib/badge-config,ui/freshness-badge,ui/freshness-badge.module.css}, src/app/analysis/[id]/page.tsx
Out-of-scope: BE verified_at 실연동(#76), ClaimAttribution 페이지 데이터 wire, 5단계에서 3단계 축소(UX 테스트 후 결정)
<!-- SAFE_OP_END -->

## 변경
- FreshnessBadge 아이콘 제거(NN/g 비보편 아이콘 회피), 라벨 안정→양호 / 노후화→재확인 권장 / 노후→오래됨 / 만료→기한 지남
- ResultCardSnapshot.freshness 타입 + freshnessSnapshotFromIso(ISO를 createdAtMs로, NaN 가드) 매퍼 추가
- ResultCard 최상단에 FreshnessBadge wire, 결과 페이지가 article.createdAt 임시 프록시로 매핑
- 5-bucket 단계 수와 임계값은 유지

## Done
- [x] FreshnessBadge wire(ResultCard 최상단) + 페이지 프록시 매핑
- [x] 아이콘 제거 + 라벨 옵션 B
- [x] freshnessSnapshotFromIso 단위 테스트(유효 ISO / NaN)
- [x] 통합 테스트(최상단 role=status + 아이콘 부재)
- [x] 회귀 시뮬레이션 ABC(state/logic/contract) 6 로그
- [x] typecheck / eslint / stylelint / arch / check:names / check:cache / build / unit 98 / browser 13 GREEN

## 검증
회귀 시뮬레이션 ABC: A(렌더 게이팅 제거)는 통합 테스트 FAIL, B(aging ariaPrefix 변조)는 배지 테스트 FAIL, C(NaN 가드 제거)는 매퍼 테스트 FAIL, 각 복구 후 PASS. 로그는 워크스페이스 `.plans/64-freshness-badge-wire-2026-05-30/regression-sim/`.

임시 프록시 리스크: 사용자 노출 라벨이 임시로 검증 시각처럼 보일 수 있음. BE verified_at(#76) 교체 예정(ADR-024 Amendment A3).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 결과 카드에 신선도 상태 배지 표시 추가
  
* **Bug Fixes**
  * 신선도 배지의 라벨 텍스트 개선 및 명확화
  * 접근성 강화를 위한 상태 정보 ARIA 레이블 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/truthscope-smu/truthscope-web-frontend/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->