### PR TITLE
✨feat(api): 키리스 BYOK 폴백 Edge 프록시 (#45)

### DIFF
--- a/src/06-entities/article/api/__tests__/backend.test.ts
+++ b/src/06-entities/article/api/__tests__/backend.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { requestArticleExtraction } from '../backend';
+import { AppError } from '@/07-shared/errors';
+
+/**
+ * #45 키리스 Edge 프록시 — requestArticleExtraction이 same-origin 프록시 경로를
+ * 경유하는지(T5), BE 4xx 메시지가 프록시 패스스루를 거쳐 AppError까지 보존되는지(T5-b) 검증.
+ */
+describe('requestArticleExtraction (#45 키리스 Edge 프록시)', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('T5: same-origin 프록시 경로(/api/proxy/analysis-sessions)로 호출하고 BE 응답을 Article로 합성한다', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          sessionId: 's-1',
+          status: 'EXTRACTING',
+          articleId: 'a-1',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+
+    const article = await requestArticleExtraction(
+      'https://news.example.com/a'
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // baseUrl '' → BE direct가 아니라 same-origin 상대 경로로 호출
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/proxy/analysis-sessions');
+
+    const snapshot = article.toSnapshot();
+    expect(snapshot.id).toBe('a-1');
+    expect(snapshot.status).toBe('EXTRACTED'); // EXTRACTING → EXTRACTED 매핑 보존
+  });
+
+  it('T5-b: 프록시가 패스스루한 BE 4xx 메시지가 AppError까지 보존된다 (Round 2 C2-1)', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          message: '분석 대상 URL에 접근할 수 없습니다',
+          statusCode: 422,
+        }),
+        { status: 422, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+
+    const error = await requestArticleExtraction(
+      'https://news.example.com/a'
+    ).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(AppError);
+    expect((error as AppError).message).toBe(
+      '분석 대상 URL에 접근할 수 없습니다'
+    );
+    expect((error as AppError).statusCode).toBe(422);
+  });
+});

--- a/src/06-entities/article/api/backend.ts
+++ b/src/06-entities/article/api/backend.ts
@@ -17,12 +17,17 @@ import type { Article } from '@06-entities/article/model/article';
 /**
  * rev.7 P21-5-1: BE PR #29 6ad70ec articleId 노출.
  * `POST /analysis-sessions` 응답 {sessionId, status, articleId} → fromAnalysisSession으로 Article 합성.
+ *
+ * #45 (ADR-025): 키리스(BYOK 미설정) 분석은 same-origin Edge 프록시를 경유한다
+ * (baseUrl '' → /api/proxy/analysis-sessions). 프록시가 X-User-Gemini-Key 없이
+ * BE로 중계하고 BE가 서버 기본 키로 fallback한다. 응답은 프록시가 status+body 그대로
+ * 패스스루하므로 ArticleExtractionResponse 매핑은 영향받지 않는다.
  */
 export async function requestArticleExtraction(url: string): Promise<Article> {
   const response = await apiClient.post<
     ArticleExtractionResponse,
     ArticleExtractionRequest
-  >('/analysis-sessions', { url });
+  >('/api/proxy/analysis-sessions', { url }, { baseUrl: '' });
   return fromAnalysisSession(url, response);
 }
 

--- a/src/07-shared/api/base.ts
+++ b/src/07-shared/api/base.ts
@@ -8,6 +8,11 @@ interface RequestOptions<B = unknown> extends Omit<
   'body' | 'method'
 > {
   body?: B;
+  /**
+   * 기본값은 config.api.baseUrl(Spring Boot BE). same-origin 호출 시 ''를 전달해
+   * 상대 경로(예: /api/proxy/analysis-sessions)로 요청한다. (#45 Edge 키리스 프록시)
+   */
+  baseUrl?: string;
 }
 
 interface BackendErrorBody {
@@ -21,8 +26,8 @@ async function request<T, B = unknown>(
   path: string,
   options: RequestOptions<B> = {}
 ): Promise<T> {
-  const { body, headers, ...rest } = options;
-  const url = `${config.api.baseUrl}${path}`;
+  const { body, headers, baseUrl, ...rest } = options;
+  const url = `${baseUrl ?? config.api.baseUrl}${path}`;
   const hasBody = body !== undefined;
 
   const requestHeaders = new Headers(headers);

--- a/src/app/api/proxy/analysis-sessions/__tests__/route.test.ts
+++ b/src/app/api/proxy/analysis-sessions/__tests__/route.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { POST } from '../route';
+import { config } from '@/07-shared/config/config';
+
+/**
+ * #45 키리스 Edge route handler — 키 헤더 미전달(T4-1), body 전달(T4-2),
+ * BE status 패스스루(T4-3), 잘못된 body 400(T4-4), fetch 실패 502(T4-5) 검증.
+ */
+describe('POST /api/proxy/analysis-sessions (#45 키리스 Edge 프록시)', () => {
+  const fetchMock = vi.fn();
+  const BE_URL = `${config.api.baseUrl}/analysis-sessions`;
+
+  function makeRequest(body: unknown, raw?: string): Request {
+    return new Request('http://localhost/api/proxy/analysis-sessions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: raw ?? JSON.stringify(body),
+    });
+  }
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          sessionId: 's-1',
+          status: 'EXTRACTING',
+          articleId: 'a-1',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('T4-1: BE로 X-User-Gemini-Key 헤더를 전달하지 않는다 (키리스 레인)', async () => {
+    await POST(makeRequest({ url: 'https://news.example.com/a' }));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const headers = new Headers(init.headers);
+    expect(headers.has('X-User-Gemini-Key')).toBe(false);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(BE_URL);
+  });
+
+  it('T4-2: 요청 body를 BE로 그대로 전달한다', async () => {
+    await POST(makeRequest({ url: 'https://news.example.com/a' }));
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual({
+      url: 'https://news.example.com/a',
+    });
+  });
+
+  it('T4-3: BE status를 그대로 패스스루한다 (4xx 보존)', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({ message: 'BE 검증 실패', statusCode: 400 }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+
+    const res = await POST(makeRequest({ url: 'https://news.example.com/a' }));
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      message: 'BE 검증 실패',
+      statusCode: 400,
+    });
+  });
+
+  it('T4-4: 잘못된 요청 body는 400을 반환하고 BE를 호출하지 않는다', async () => {
+    const res = await POST(makeRequest(undefined, 'not-json{'));
+
+    expect(res.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('T4-5: BE fetch 실패 시 502를 반환한다', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'));
+
+    const res = await POST(makeRequest({ url: 'https://news.example.com/a' }));
+
+    expect(res.status).toBe(502);
+    expect((await res.json()).statusCode).toBe(502);
+  });
+});

--- a/src/app/api/proxy/analysis-sessions/__tests__/route.test.ts
+++ b/src/app/api/proxy/analysis-sessions/__tests__/route.test.ts
@@ -89,4 +89,22 @@ describe('POST /api/proxy/analysis-sessions (#45 키리스 Edge 프록시)', () 
     expect(res.status).toBe(502);
     expect((await res.json()).statusCode).toBe(502);
   });
+
+  it('T4-6: 배열 body는 400을 반환하고 BE를 호출하지 않는다 (CodeRabbit Minor)', async () => {
+    const res = await POST(makeRequest([1, 2, 3]));
+
+    expect(res.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('T4-7: BE 응답 타임아웃 시 504를 반환한다 (CodeRabbit Major)', async () => {
+    fetchMock.mockRejectedValue(
+      new DOMException('The operation timed out.', 'TimeoutError')
+    );
+
+    const res = await POST(makeRequest({ url: 'https://news.example.com/a' }));
+
+    expect(res.status).toBe(504);
+    expect((await res.json()).statusCode).toBe(504);
+  });
 });

--- a/src/app/api/proxy/analysis-sessions/route.ts
+++ b/src/app/api/proxy/analysis-sessions/route.ts
@@ -1,0 +1,57 @@
+import { config } from '@/07-shared/config/config';
+
+export const runtime = 'edge';
+
+/**
+ * 키리스(BYOK 미설정) 분석 요청 전용 same-origin 레인. (#45 / ADR-025)
+ *
+ * X-User-Gemini-Key를 주입하거나 전달하지 않는다 → BE가 헤더 부재 시 서버 기본 키로
+ * fallback한다(NewsController). 따라서 이 핸들러는 "키 은닉·남용 방지"가 목적이 아니라
+ * same-origin(CORS 회피) + BE URL 은닉 + 향후 rate limit/감사 seam이 목적이다.
+ * (키는 원래 BE 서버측에만 있어 클라이언트에 노출된 적이 없다.)
+ *
+ * rate limit(남용 방지)은 본 핸들러 범위 밖 — 후속(BE Bucket4j #89 또는 Edge).
+ * BYOK 설정 사용자의 우회 분기도 범위 밖 — BYOK attach 배선이 생기면 이 레인 앞에서 분기한다.
+ */
+export async function POST(request: Request): Promise<Response> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    body = undefined;
+  }
+  // 잘못된 JSON(런타임에 따라 throw 또는 undefined 반환) + 객체가 아닌 body를 일관되게 거부.
+  if (typeof body !== 'object' || body === null) {
+    return Response.json(
+      { message: '잘못된 요청 본문입니다', statusCode: 400 },
+      { status: 400 }
+    );
+  }
+
+  let beRes: Response;
+  try {
+    beRes = await fetch(`${config.api.baseUrl}/analysis-sessions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+  } catch {
+    return Response.json(
+      { message: '분석 서버에 연결할 수 없습니다', statusCode: 502 },
+      { status: 502 }
+    );
+  }
+
+  // BE 응답 status + body를 그대로 패스스루한다.
+  // (4xx/5xx를 AppError로 변환하는 책임은 클라이언트 apiClient가 담당.)
+  const text = await beRes.text();
+  return new Response(text, {
+    status: beRes.status,
+    headers: {
+      'Content-Type': beRes.headers.get('Content-Type') ?? 'application/json',
+    },
+  });
+}

--- a/src/app/api/proxy/analysis-sessions/route.ts
+++ b/src/app/api/proxy/analysis-sessions/route.ts
@@ -20,14 +20,15 @@ export async function POST(request: Request): Promise<Response> {
   } catch {
     body = undefined;
   }
-  // 잘못된 JSON(런타임에 따라 throw 또는 undefined 반환) + 객체가 아닌 body를 일관되게 거부.
-  if (typeof body !== 'object' || body === null) {
+  // 잘못된 JSON(런타임에 따라 throw 또는 undefined 반환) + 객체가 아닌 body(배열 포함)를 일관되게 거부.
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
     return Response.json(
       { message: '잘못된 요청 본문입니다', statusCode: 400 },
       { status: 400 }
     );
   }
 
+  // BE 응답 지연/hang이 무기한 대기로 번지지 않도록 타임아웃을 건다(15초 초과 시 504).
   let beRes: Response;
   try {
     beRes = await fetch(`${config.api.baseUrl}/analysis-sessions`, {
@@ -37,8 +38,15 @@ export async function POST(request: Request): Promise<Response> {
         Accept: 'application/json',
       },
       body: JSON.stringify(body),
+      signal: AbortSignal.timeout(15000),
     });
-  } catch {
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'TimeoutError') {
+      return Response.json(
+        { message: '분석 서버 응답이 지연되고 있습니다', statusCode: 504 },
+        { status: 504 }
+      );
+    }
     return Response.json(
       { message: '분석 서버에 연결할 수 없습니다', statusCode: 502 },
       { status: 502 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -68,6 +68,7 @@ export default defineConfig({
             'src/05-features/**/model/**/*.test.ts',
             'src/05-features/**/api*.test.ts',
             'src/04-widgets/**/lib/**/*.test.ts',
+            'src/app/api/**/__tests__/**/*.test.ts',
             'test/architecture.test.ts',
           ],
         },


### PR DESCRIPTION
## 개요

BYOK(자기 API 키) 미설정 사용자의 분석 요청을 Vercel Edge route handler가 same-origin으로 받아 BE로 중계한다. `X-User-Gemini-Key`를 주입하지 않으므로 BE가 서버 기본 키로 fallback한다(NewsController 실측). FE #45 / S4-01 / ADR-025.

가치는 보안 프록시가 아니라 **same-origin(CORS 회피) + BE URL 은닉 + 향후 rate limit/감사 seam**이다. rate limit(남용 방지)은 본 PR 범위 밖 — 후속(BE Bucket4j #89 또는 Edge). 키는 원래 BE 서버측에만 있어 클라이언트에 노출된 적이 없다.

## 변경

- `src/app/api/proxy/analysis-sessions/route.ts` (신규) — Edge runtime POST 핸들러. body를 받아 키 헤더 없이 `${baseUrl}/analysis-sessions`로 중계, BE status+body 패스스루. 잘못된 body 400, fetch 실패 502.
- `src/07-shared/api/base.ts` — `RequestOptions`에 optional `baseUrl` 추가(additive). same-origin 호출 시 `''` 전달.
- `src/06-entities/article/api/backend.ts` — `requestArticleExtraction`이 BE 직접 호출 대신 same-origin `/api/proxy/analysis-sessions` 호출(`baseUrl: ''`).
- 테스트: route handler 5건(키 미전달/body 전달/status 패스스루/400/502) + backend 2건(same-origin URL/4xx 메시지 보존).
- `vitest.config.ts` — unit project include에 `src/app/api/**/__tests__` 추가.

ADR-025(신규, ADR-004 §b-edge-injection 부분 supersede)는 `context/`에 박제(git 비추적 워크스페이스).

## Done

- [x] **요구사항(AC)**: 키 미설정 분석 요청이 same-origin `/api/proxy/analysis-sessions` 경유 → BE 중계(키 헤더 없음) → BE status+body 패스스루. 잘못된 body 400, BE 연결 실패 502.
- [x] **산출물**: Edge route handler `POST /api/proxy/analysis-sessions` + `apiClient` baseUrl 옵션 + `requestArticleExtraction` 전환.
- [x] **수용 테스트(unit)**: route 5 + backend 2 = 7/7 PASS. 회귀 시뮬레이션 ABC(경로/키주입/status) 무력화→FAIL→복구→PASS 실측.

## 검증

- typecheck ✓ / eslint ✓ / prettier ✓ / `next build` ✓ (`ƒ /api/proxy/analysis-sessions` 라우트 컴파일 확인)
- unit 7/7 + 전체 unit 회귀 무영향
- 회귀 ABC: `.plans/65-fe45-vercel-edge-byok-proxy-2026-05-30/regression-sim/ABC-2026-05-30.md`

E2E(폼→proxy→BE)는 로컬 BE 기동 필요로 별도. 프로덕션 배포는 BE 공개 도달처(EC2 vs PaaS) 확정 후.

<!-- SAFE_OP_START -->
Assumptions: BE가 X-User-Gemini-Key 헤더 부재 시 서버 기본 키로 fallback(NewsController.java:27,37 실측). BE는 CORS 미설정(SecurityConfig permitAll)이라 Edge→BE 서버간 중계 비차단.
Scope: src/app/api/proxy/analysis-sessions/, src/07-shared/api/base.ts, src/06-entities/article/api/backend.ts(+test), vitest.config.ts
Out-of-scope: rate limit(BE Bucket4j #89 후속), BYOK 설정 사용자 우회 분기(BYOK attach 배선 후), requestAnalysis dead code, 프로덕션 배포
<!-- SAFE_OP_END -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 기사 추출 및 프록시 API 호출에 대한 테스트 케이스 추가

* **Chores**
  * API 호출 경로 최적화 및 설정 옵션 확장

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/truthscope-smu/truthscope-web-frontend/pull/60?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->