### PR TITLE
🐛fix(proxy): 분석 추출 일시 실패 시 자동 재시도 + 에러 응답 정돈

### DIFF
--- a/src/app/api/proxy/analysis-sessions/__tests__/route.test.ts
+++ b/src/app/api/proxy/analysis-sessions/__tests__/route.test.ts
@@ -107,4 +107,87 @@ describe('POST /api/proxy/analysis-sessions (#45 키리스 Edge 프록시)', () 
     expect(res.status).toBe(504);
     expect((await res.json()).statusCode).toBe(504);
   });
+
+  it('T4-8: BE 5xx 후 성공 시 자동 재시도하여 성공을 반환한다 (일시 추출 실패 완화)', async () => {
+    fetchMock.mockReset();
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            message: '기사를 가져올 수 없습니다',
+            statusCode: 500,
+          }),
+          { status: 500, headers: { 'Content-Type': 'application/json' } }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            sessionId: 's-2',
+            status: 'EXTRACTING',
+            articleId: 'a-2',
+          }),
+          { status: 201, headers: { 'Content-Type': 'application/json' } }
+        )
+      );
+
+    const res = await POST(makeRequest({ url: 'https://news.example.com/a' }));
+
+    expect(res.status).toBe(201);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('T4-9: BE 5xx가 계속되면 최대 3회 시도 후 마지막 5xx를 패스스루한다', async () => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          message: '기사를 가져올 수 없습니다',
+          statusCode: 500,
+        }),
+        { status: 500, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+
+    const res = await POST(makeRequest({ url: 'https://news.example.com/a' }));
+
+    expect(res.status).toBe(500);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('T4-10: 4xx는 재시도하지 않고 즉시 패스스루한다', async () => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({ message: 'BE 검증 실패', statusCode: 400 }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+
+    const res = await POST(makeRequest({ url: 'https://news.example.com/a' }));
+
+    expect(res.status).toBe(400);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('T4-11: 일시 네트워크 오류 후 성공 시 자동 재시도한다 (타임아웃 아님)', async () => {
+    fetchMock.mockReset();
+    fetchMock
+      .mockRejectedValueOnce(new Error('connection reset'))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            sessionId: 's-3',
+            status: 'EXTRACTING',
+            articleId: 'a-3',
+          }),
+          { status: 201, headers: { 'Content-Type': 'application/json' } }
+        )
+      );
+
+    const res = await POST(makeRequest({ url: 'https://news.example.com/a' }));
+
+    expect(res.status).toBe(201);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/app/api/proxy/analysis-sessions/route.ts
+++ b/src/app/api/proxy/analysis-sessions/route.ts
@@ -13,6 +13,10 @@ export const runtime = 'edge';
  * rate limit(남용 방지)은 본 핸들러 범위 밖 — 후속(BE Bucket4j #89 또는 Edge).
  * BYOK 설정 사용자의 우회 분기도 범위 밖 — BYOK attach 배선이 생기면 이 레인 앞에서 분기한다.
  */
+// 최초 1회 + 일시 실패 시 재시도 2회. korea.kr 추출이 간헐적으로 실패(BE 5xx)하거나
+// 일시 네트워크 오류가 날 때, 사용자가 분석 버튼을 다시 누르지 않아도 자동으로 재시도한다.
+const MAX_ATTEMPTS = 3;
+
 export async function POST(request: Request): Promise<Response> {
   let body: unknown;
   try {
@@ -28,38 +32,66 @@ export async function POST(request: Request): Promise<Response> {
     );
   }
 
-  // BE 응답 지연/hang이 무기한 대기로 번지지 않도록 타임아웃을 건다(15초 초과 시 504).
-  let beRes: Response;
-  try {
-    beRes = await fetch(`${config.api.baseUrl}/analysis-sessions`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Accept: 'application/json',
-      },
-      body: JSON.stringify(body),
-      signal: AbortSignal.timeout(15000),
-    });
-  } catch (error) {
-    if (error instanceof DOMException && error.name === 'TimeoutError') {
+  const payload = JSON.stringify(body);
+
+  // 자동 재시도 루프. 재시도 대상은 일시적 실패(BE 5xx, 일시 네트워크 오류)뿐이다.
+  // 4xx(요청 오류)는 결정적이라 즉시 패스스루하고, 타임아웃은 이미 15초를 기다렸으므로
+  // 재시도하지 않고 504로 끊는다(누적 대기 폭증 방지).
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    let beRes: Response;
+    try {
+      beRes = await fetch(`${config.api.baseUrl}/analysis-sessions`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: payload,
+        signal: AbortSignal.timeout(15000),
+      });
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'TimeoutError') {
+        return Response.json(
+          { message: '분석 서버 응답이 지연되고 있습니다', statusCode: 504 },
+          { status: 504 }
+        );
+      }
+      if (attempt < MAX_ATTEMPTS) {
+        continue;
+      }
       return Response.json(
-        { message: '분석 서버 응답이 지연되고 있습니다', statusCode: 504 },
-        { status: 504 }
+        { message: '분석 서버에 연결할 수 없습니다', statusCode: 502 },
+        { status: 502 }
       );
     }
-    return Response.json(
-      { message: '분석 서버에 연결할 수 없습니다', statusCode: 502 },
-      { status: 502 }
-    );
+
+    // 5xx = 일시 실패로 간주. 남은 시도가 있으면 재시도, 마지막 시도면 그대로 패스스루한다.
+    if (beRes.status >= 500 && attempt < MAX_ATTEMPTS) {
+      continue;
+    }
+
+    // BE 응답 status + body 패스스루. body 읽기 실패 등 예기치 못한 예외도 JSON으로 감싸
+    // Next 기본 에러 HTML 페이지가 클라이언트로 새어 나가지 않게 한다.
+    try {
+      const text = await beRes.text();
+      return new Response(text, {
+        status: beRes.status,
+        headers: {
+          'Content-Type':
+            beRes.headers.get('Content-Type') ?? 'application/json',
+        },
+      });
+    } catch {
+      return Response.json(
+        { message: '분석 서버 응답을 읽을 수 없습니다', statusCode: 502 },
+        { status: 502 }
+      );
+    }
   }
 
-  // BE 응답 status + body를 그대로 패스스루한다.
-  // (4xx/5xx를 AppError로 변환하는 책임은 클라이언트 apiClient가 담당.)
-  const text = await beRes.text();
-  return new Response(text, {
-    status: beRes.status,
-    headers: {
-      'Content-Type': beRes.headers.get('Content-Type') ?? 'application/json',
-    },
-  });
+  // 루프는 항상 반환하므로 정상 흐름에서 도달하지 않는다. 타입 안전용 방어 반환.
+  return Response.json(
+    { message: '분석 요청을 처리하지 못했습니다', statusCode: 502 },
+    { status: 502 }
+  );
 }


### PR DESCRIPTION
## Done
- 요구사항: 분석 추출이 간헐적으로 실패(BE 5xx)하거나 일시 네트워크 오류가 날 때, 사용자가 "분석 시작"을 다시 누르지 않아도 자동 재시도로 성공하게 한다.
- 산출물: `src/app/api/proxy/analysis-sessions/route.ts` (재시도 루프 + 에러 응답 정돈), 같은 경로 `__tests__/route.test.ts` (T4-8~T4-11 추가)
- 수용 테스트: route.test.ts 11/11 통과 — 5xx→재시도→성공 / 5xx 3회→마지막 패스스루 / 4xx 재시도 안 함 / 일시 네트워크 오류 재시도 / 타임아웃 즉시 504

<!-- SAFE_OP_START -->
Assumptions: 재시도 대상은 일시 실패(BE 5xx, 비-타임아웃 네트워크 오류)뿐. 4xx(요청 오류)와 타임아웃(이미 15초 대기)은 재시도하지 않는다(누적 대기 폭증 방지).
Scope: src/app/api/proxy/analysis-sessions/route.ts, src/app/api/proxy/analysis-sessions/__tests__/route.test.ts
Out-of-scope: BE 추출 안정화(korea.kr 차단 자체), 점수 산식, FE 폼/UI, 기타 format 줄바꿈 churn
<!-- SAFE_OP_END -->

## 배경
프록시 핸들러, apiClient, BE 어디에도 "에러 캐시"는 존재하지 않음(코드 경로 전체 추적으로 확인). 같은 URL 재요청은 BE에서 매번 새 article을 만들며 대개 성공함(실측: 연속 10회 중 2회 실패 후 8연속 성공). 즉 증상의 원인은 "캐시"가 아니라 **간헐적 추출 실패**이므로, 캐시 제거가 아니라 **자동 재시도**가 근본원인에 맞는 수정이다.

부수적으로, 드물게 Edge 핸들러가 예외를 던져 Next 기본 에러 HTML(`__next_error__`)이 클라이언트로 노출되던 경로를 body 읽기 try/catch로 감싸 깔끔한 JSON 에러로 정돈했다.

## 검증
- `npm run typecheck` / `npm run lint` / `npm run build` 통과
- `npx vitest run .../route.test.ts` 11/11 통과

## 변경 요약 (재시도 정책)
- 최초 1회 + 재시도 2회 (`MAX_ATTEMPTS = 3`)
- 5xx 응답: 남은 시도 있으면 재시도, 마지막이면 그대로 패스스루
- 비-타임아웃 네트워크 throw: 재시도, 마지막이면 502
- 타임아웃(15초): 재시도 없이 즉시 504
- 4xx: 재시도 없이 즉시 패스스루


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * API 요청 시 일시적인 네트워크 오류나 서버 오류(5xx)에 대해 자동 재시도 기능이 추가되었습니다.

* **테스트**
  * 자동 재시도 동작에 대한 다양한 시나리오 테스트 케이스가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->