### PR TITLE
✨feat: Phase 70 — /history 실데이터 바인딩 + 분석 요청 토큰 전달

### DIFF
--- a/src/03-pages/history/__tests__/history-page.test.tsx
+++ b/src/03-pages/history/__tests__/history-page.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { HistoryPage } from '../history-page';
+import type { AnalysisSessionListItem } from '@/06-entities/analysis-session';
+
+afterEach(cleanup);
+
+const MOCK_SESSIONS: AnalysisSessionListItem[] = [
+  {
+    sessionId: 'session-1',
+    articleId: 'article-1',
+    articleTitle: '반도체 시장 2026년 전망',
+    articleUrl: 'https://news.example.com/semiconductor',
+    articleDomain: 'news.example.com',
+    status: 'COMPLETED',
+    totalScore: 82,
+    requestedAt: '2026-06-01T10:00:00Z',
+    completedAt: '2026-06-01T10:01:30Z',
+  },
+  {
+    sessionId: 'session-2',
+    articleId: null,
+    articleTitle: null,
+    articleUrl: 'https://news.example.com/another',
+    articleDomain: null,
+    status: 'ANALYZING',
+    totalScore: null,
+    requestedAt: '2026-06-01T11:00:00Z',
+    completedAt: null,
+  },
+];
+
+describe('HistoryPage — 빈 상태', () => {
+  it('sessions이 빈 배열이면 빈 상태 문구를 렌더한다', () => {
+    render(<HistoryPage sessions={[]} />);
+    expect(
+      screen.getByText(
+        '아직 분석 이력이 없습니다. 기사를 분석하면 여기에 표시됩니다.'
+      )
+    ).toBeDefined();
+  });
+});
+
+describe('HistoryPage — 목록 렌더', () => {
+  it('sessions 배열이 있으면 기사 제목을 렌더한다', () => {
+    render(<HistoryPage sessions={MOCK_SESSIONS} />);
+    expect(screen.getByText('반도체 시장 2026년 전망')).toBeDefined();
+  });
+
+  it('totalScore가 null인 항목은 "검증 가능 주장 없음"을 렌더한다', () => {
+    render(<HistoryPage sessions={MOCK_SESSIONS} />);
+    expect(screen.getByText('검증 가능 주장 없음')).toBeDefined();
+  });
+
+  it('totalScore가 존재하는 항목은 점수/100 형식으로 렌더한다', () => {
+    render(<HistoryPage sessions={MOCK_SESSIONS} />);
+    expect(screen.getByText('82/100')).toBeDefined();
+  });
+});

--- a/src/03-pages/history/history-page.tsx
+++ b/src/03-pages/history/history-page.tsx
@@ -1,338 +1,132 @@
+import type { AnalysisSessionListItem } from '@/06-entities/analysis-session';
 import {
   BadgeCheckIcon,
-  ChevronLeftIcon,
   ChevronRightIcon,
-  FilterIcon,
-  HelpCircleIcon,
   ICON_SIZE,
-  SearchIcon,
-  SortIcon,
-  TriangleAlertIcon,
 } from '@/07-shared/ui/icons';
 
-export function HistoryPage() {
+// ADR-019 정합 라벨 — "신뢰도 점수" 표현 회피(신뢰도 직접 등치 금지).
+const SCORE_LABEL = '검증 가능 주장 기준 종합 점수';
+const EMPTY_SCORE = '검증 가능 주장 없음';
+
+const DATE_FMT = new Intl.DateTimeFormat('ko-KR', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+});
+
+function formatDate(iso: string): string {
+  return DATE_FMT.format(new Date(iso));
+}
+
+function statusLabel(status: string): string {
+  switch (status) {
+    case 'COMPLETED':
+      return '검증 완료';
+    case 'FAILED':
+      return '분석 실패';
+    default:
+      return '분석 중';
+  }
+}
+
+interface HistoryItemProps {
+  session: AnalysisSessionListItem;
+}
+
+function HistoryItem({ session: s }: HistoryItemProps) {
+  const displayDate = formatDate(s.completedAt ?? s.requestedAt);
+  const scoreDisplay =
+    s.totalScore === null ? EMPTY_SCORE : `${s.totalScore}/100`;
+  const canLink = s.status === 'COMPLETED' && s.articleId !== null;
+
   return (
-    <>
-      <main className="mx-auto max-w-7xl px-8 py-12">
-        <header className="mb-12">
-          <h1 className="font-pretendard text-primary mb-2 text-5xl font-black tracking-tighter">
-            히스토리 & 인사이트
-          </h1>
-          <p className="font-pretendard text-on-surface-variant max-w-2xl text-body-md">
-            신뢰도 분석 결과의 종합적인 개요와 전 세계 섹터별 정보 신뢰성 변화
-            추이를 확인하세요.
-          </p>
-        </header>
+    <li className="rounded-2xl border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface-raised)] p-6">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center">
+        <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-xl bg-[var(--color-brand-subtle)] text-[var(--color-brand-primary)]">
+          <BadgeCheckIcon aria-hidden="true" className={ICON_SIZE.md} />
+        </div>
 
-        <section className="mb-16 grid grid-cols-1 gap-6 md:grid-cols-3">
-          {/* Global Trust Gauge */}
-          <div className="bg-surface-container-lowest relative flex flex-col items-center justify-center overflow-hidden rounded-full p-8 text-center shadow-sm md:col-span-1">
-            <div className="from-secondary/5 pointer-events-none absolute inset-0 bg-gradient-to-tr to-transparent"></div>
-            <span className="font-pretendard text-secondary mb-4 text-label-md font-semibold tracking-widest uppercase">
-              현재 신뢰도 점수
+        <div className="flex-grow">
+          <div className="mb-1 flex flex-wrap items-center gap-2">
+            <span className="font-pretendard text-[var(--color-text-secondary)] text-xs font-semibold uppercase tracking-wider">
+              {statusLabel(s.status)}
             </span>
-            <div className="relative mb-4 h-24 w-48">
-              <svg
-                className="h-full w-full transform transition-transform duration-500 hover:scale-105"
-                viewBox="0 0 100 50"
-              >
-                <path
-                  className="text-surface-container-highest"
-                  d="M 10 50 A 40 40 0 0 1 90 50"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="8"
-                ></path>
-                <path
-                  d="M 10 50 A 40 40 0 0 1 72 15"
-                  fill="none"
-                  stroke="url(#trustGradient)"
-                  strokeLinecap="round"
-                  strokeWidth="10"
-                ></path>
-                <defs>
-                  <linearGradient
-                    id="trustGradient"
-                    x1="0%"
-                    x2="100%"
-                    y1="0%"
-                    y2="0%"
-                  >
-                    <stop
-                      offset="0%"
-                      style={{ stopColor: 'var(--color-blue-900)' }}
-                    ></stop>
-                    <stop
-                      offset="100%"
-                      style={{ stopColor: 'var(--color-blue-700)' }}
-                    ></stop>
-                  </linearGradient>
-                </defs>
-              </svg>
-              <div className="font-pretendard text-primary absolute bottom-0 left-1/2 -translate-x-1/2 text-4xl font-black">
-                78%
-              </div>
-            </div>
-            <p className="font-pretendard text-on-surface-variant text-body-sm">
-              지난달 대비 신뢰도 지수 4.2% 상승
+            <span className="text-[var(--color-text-secondary)] text-xs">
+              {displayDate}
+            </span>
+          </div>
+          <p className="font-pretendard text-[var(--color-text-heading)] text-base font-bold">
+            {s.articleTitle ?? (s.articleUrl ? s.articleUrl : '기사 제목 없음')}
+          </p>
+          {s.articleDomain && (
+            <p className="font-pretendard text-[var(--color-text-secondary)] mt-0.5 text-xs">
+              {s.articleDomain}
             </p>
-          </div>
+          )}
+        </div>
 
-          {/* Reliability by Category */}
-          <div className="bg-surface-container-low rounded-full p-8 shadow-sm md:col-span-2">
-            <div className="mb-8 flex items-start justify-between">
-              <h3 className="font-pretendard text-primary text-xl font-bold">
-                카테고리별 신뢰도 추이
-              </h3>
-              <div className="flex gap-2">
-                <span className="text-secondary flex items-center gap-2 text-body-sm font-pretendard font-medium">
-                  <span className="bg-secondary h-2 w-2 rounded-full"></span>{' '}
-                  검증됨
-                </span>
-                <span className="text-outline flex items-center gap-2 text-body-sm font-pretendard font-medium">
-                  <span className="bg-outline-variant h-2 w-2 rounded-full"></span>{' '}
-                  혼합
-                </span>
-              </div>
+        <div className="flex items-center gap-6 md:flex-shrink-0">
+          <div className="text-right">
+            <div className="font-pretendard text-[var(--color-action-hero)] text-xl font-black">
+              {scoreDisplay}
             </div>
-            <div className="space-y-6">
-              <div className="space-y-2">
-                <div className="font-pretendard text-on-surface flex justify-between text-label-md font-semibold">
-                  <span>정치</span>
-                  <span>64%</span>
-                </div>
-                <div className="bg-surface-container-highest h-3 w-full overflow-hidden rounded-full">
-                  <div className="bg-secondary h-full w-[64%] rounded-full"></div>
-                </div>
-              </div>
-              <div className="space-y-2">
-                <div className="font-pretendard text-on-surface flex justify-between text-label-md font-semibold">
-                  <span>기술 & AI</span>
-                  <span>91%</span>
-                </div>
-                <div className="bg-surface-container-highest h-3 w-full overflow-hidden rounded-full">
-                  <div className="bg-secondary h-full w-[91%] rounded-full"></div>
-                </div>
-              </div>
-              <div className="space-y-2">
-                <div className="font-pretendard text-on-surface flex justify-between text-label-md font-semibold">
-                  <span>글로벌 경제</span>
-                  <span>82%</span>
-                </div>
-                <div className="bg-surface-container-highest h-3 w-full overflow-hidden rounded-full">
-                  <div className="bg-secondary h-full w-[82%] rounded-full"></div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <section>
-          <div className="mb-8 flex flex-col justify-between gap-4 md:flex-row md:items-center">
-            <h2 className="font-pretendard text-primary text-3xl font-black">
-              분석 아카이브
-            </h2>
-            <div className="flex flex-wrap items-center gap-3">
-              <div className="group relative">
-                <SearchIcon
-                  aria-hidden="true"
-                  className={`text-on-surface-variant absolute left-3 top-1/2 -translate-y-1/2 ${ICON_SIZE.sm}`}
-                />
-                <input
-                  className="bg-surface-container-highest focus:ring-secondary font-pretendard border-none py-2 pl-10 pr-4 text-body-sm w-full outline-none transition-all focus:ring-2 focus:ring-offset-4 rounded-lg md:w-64"
-                  placeholder="주장 검색..."
-                  type="text"
-                  aria-label="주장 검색"
-                />
-              </div>
-              <button
-                className="bg-surface-container-low text-on-surface-variant font-pretendard hover:bg-surface-container-high flex items-center gap-2 rounded-lg px-4 py-2 text-body-sm transition-colors"
-                type="button"
-              >
-                <FilterIcon aria-hidden="true" className={ICON_SIZE.md} />
-                필터
-              </button>
-              <button
-                className="bg-surface-container-low text-on-surface-variant font-pretendard hover:bg-surface-container-high flex items-center gap-2 rounded-lg px-4 py-2 text-body-sm transition-colors"
-                type="button"
-              >
-                <SortIcon aria-hidden="true" className={ICON_SIZE.md} />
-                날짜순 정렬
-              </button>
+            <div className="font-pretendard text-[var(--color-text-secondary)] text-xs">
+              {SCORE_LABEL}
             </div>
           </div>
 
-          <div className="space-y-4">
-            <div className="bg-surface-container-lowest hover:translate-x-2 flex flex-col items-center gap-6 rounded-full p-6 transition-transform duration-300 md:flex-row">
-              <div className="bg-secondary-container/20 text-secondary flex h-12 w-12 items-center justify-center rounded-xl">
-                <BadgeCheckIcon aria-hidden="true" className={ICON_SIZE.md} />
-              </div>
-              <div className="flex-grow">
-                <div className="mb-1 flex items-center gap-3">
-                  <span className="font-pretendard text-secondary text-label-sm font-bold tracking-tighter uppercase">
-                    검증됨
-                  </span>
-                  <span className="text-outline-variant">•</span>
-                  <span className="font-pretendard text-on-surface-variant text-label-sm">
-                    2024년 10월 24일
-                  </span>
-                </div>
-                <h4 className="font-pretendard text-primary text-lg font-bold">
-                  글로벌 반도체 생산량, 2024년 4분기 12% 증가 전망
-                </h4>
-              </div>
-              <div className="flex w-full items-center justify-between gap-8 md:w-auto md:justify-end">
-                <div className="text-right">
-                  <div className="font-pretendard text-primary text-xl font-black">
-                    98/100
-                  </div>
-                  <div className="font-pretendard text-on-surface-variant text-label-sm">
-                    신뢰도
-                  </div>
-                </div>
-                <button
-                  className="text-on-surface-variant hover:text-primary transition-colors"
-                  type="button"
-                  aria-label="상세 보기"
-                >
-                  <ChevronRightIcon
-                    aria-hidden="true"
-                    className={ICON_SIZE.sm}
-                  />
-                </button>
-              </div>
-            </div>
-
-            <div className="bg-surface-container-low hover:translate-x-2 flex flex-col items-center gap-6 rounded-full p-6 transition-transform duration-300 md:flex-row">
-              <div className="bg-surface-container-highest text-on-surface-variant flex h-12 w-12 items-center justify-center rounded-xl">
-                <HelpCircleIcon aria-hidden="true" className={ICON_SIZE.md} />
-              </div>
-              <div className="flex-grow">
-                <div className="mb-1 flex items-center gap-3">
-                  <span className="font-pretendard text-on-surface-variant text-label-sm font-bold tracking-tighter uppercase">
-                    혼합 맥락
-                  </span>
-                  <span className="text-outline-variant">•</span>
-                  <span className="font-pretendard text-on-surface-variant text-label-sm">
-                    2024년 10월 22일
-                  </span>
-                </div>
-                <h4 className="font-pretendard text-primary text-lg font-bold">
-                  새 도시계획으로 출퇴근 시간 즉시 40% 단축 주장
-                </h4>
-              </div>
-              <div className="flex w-full items-center justify-between gap-8 md:w-auto md:justify-end">
-                <div className="text-right">
-                  <div className="font-pretendard text-primary text-xl font-black">
-                    52/100
-                  </div>
-                  <div className="font-pretendard text-on-surface-variant text-label-sm">
-                    신뢰도
-                  </div>
-                </div>
-                <button
-                  className="text-on-surface-variant hover:text-primary transition-colors"
-                  type="button"
-                  aria-label="상세 보기"
-                >
-                  <ChevronRightIcon
-                    aria-hidden="true"
-                    className={ICON_SIZE.sm}
-                  />
-                </button>
-              </div>
-            </div>
-
-            <div className="bg-error-container/30 hover:translate-x-2 flex flex-col items-center gap-6 rounded-full p-6 transition-transform duration-300 md:flex-row">
-              <div className="bg-error/10 text-error flex h-12 w-12 items-center justify-center rounded-xl">
-                <TriangleAlertIcon
-                  aria-hidden="true"
-                  className={ICON_SIZE.md}
-                />
-              </div>
-              <div className="flex-grow">
-                <div className="mb-1 flex items-center gap-3">
-                  <span className="font-pretendard text-error text-label-sm font-bold tracking-tighter uppercase">
-                    부정확
-                  </span>
-                  <span className="text-outline-variant">•</span>
-                  <span className="font-pretendard text-on-surface-variant text-label-sm">
-                    2024년 10월 19일
-                  </span>
-                </div>
-                <h4 className="font-pretendard text-primary text-lg font-bold">
-                  지역 연구소 기적의 에너지 혁신 영상이라 주장하는 바이럴 영상
-                </h4>
-              </div>
-              <div className="flex w-full items-center justify-between gap-8 md:w-auto md:justify-end">
-                <div className="text-right">
-                  <div className="font-pretendard text-error text-xl font-black">
-                    14/100
-                  </div>
-                  <div className="font-pretendard text-on-surface-variant text-label-sm">
-                    신뢰도
-                  </div>
-                </div>
-                <button
-                  className="text-on-surface-variant hover:text-primary transition-colors"
-                  type="button"
-                  aria-label="상세 보기"
-                >
-                  <ChevronRightIcon
-                    aria-hidden="true"
-                    className={ICON_SIZE.sm}
-                  />
-                </button>
-              </div>
-            </div>
-          </div>
-
-          {/* Pagination */}
-          <div className="mt-12 flex items-center justify-center gap-4">
-            <button
-              className="border-outline-variant/30 text-on-surface-variant hover:bg-surface-container-low flex h-10 w-10 items-center justify-center rounded-full border transition-colors"
-              type="button"
-              aria-label="이전 페이지"
-            >
-              <ChevronLeftIcon aria-hidden="true" className={ICON_SIZE.sm} />
-            </button>
-            <div className="flex items-center gap-2">
-              <button
-                className="bg-primary text-on-primary font-pretendard h-10 w-10 rounded-full font-bold"
-                type="button"
-              >
-                1
-              </button>
-              <button
-                className="text-on-surface-variant hover:bg-surface-container-low font-pretendard h-10 w-10 rounded-full"
-                type="button"
-              >
-                2
-              </button>
-              <button
-                className="text-on-surface-variant hover:bg-surface-container-low font-pretendard h-10 w-10 rounded-full"
-                type="button"
-              >
-                3
-              </button>
-              <span className="text-outline-variant">...</span>
-              <button
-                className="text-on-surface-variant hover:bg-surface-container-low font-pretendard h-10 w-10 rounded-full"
-                type="button"
-              >
-                12
-              </button>
-            </div>
-            <button
-              className="border-outline-variant/30 text-on-surface-variant hover:bg-surface-container-low flex h-10 w-10 items-center justify-center rounded-full border transition-colors"
-              type="button"
-              aria-label="다음 페이지"
+          {canLink ? (
+            <a
+              href={`/analysis/${s.articleId}`}
+              aria-label="상세 보기"
+              className="text-[var(--color-text-secondary)] transition-colors hover:text-[var(--color-text-heading)]"
             >
               <ChevronRightIcon aria-hidden="true" className={ICON_SIZE.sm} />
-            </button>
-          </div>
-        </section>
-      </main>
-    </>
+            </a>
+          ) : (
+            <span
+              aria-hidden="true"
+              className="text-[var(--color-border-subtle)]"
+            >
+              <ChevronRightIcon className={ICON_SIZE.sm} />
+            </span>
+          )}
+        </div>
+      </div>
+    </li>
+  );
+}
+
+interface HistoryPageProps {
+  sessions: AnalysisSessionListItem[];
+}
+
+export function HistoryPage({ sessions }: HistoryPageProps) {
+  return (
+    <main className="mx-auto max-w-7xl px-8 py-12">
+      <header className="mb-12">
+        <h1 className="font-pretendard text-[var(--color-text-heading)] mb-2 text-5xl font-black tracking-tighter">
+          분석 이력
+        </h1>
+        <p className="font-pretendard text-[var(--color-text-secondary)] max-w-2xl text-body-md">
+          내가 검증한 기사들의 결과를 모아봅니다.
+        </p>
+      </header>
+
+      {sessions.length === 0 ? (
+        <div className="rounded-2xl border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface-raised)] p-12 text-center">
+          <p className="font-pretendard text-[var(--color-text-secondary)] text-body-md">
+            아직 분석 이력이 없습니다. 기사를 분석하면 여기에 표시됩니다.
+          </p>
+        </div>
+      ) : (
+        <ul className="space-y-4">
+          {sessions.map((s) => (
+            <HistoryItem key={s.sessionId} session={s} />
+          ))}
+        </ul>
+      )}
+    </main>
   );
 }

--- a/src/06-entities/analysis-session/__tests__/list.test.ts
+++ b/src/06-entities/analysis-session/__tests__/list.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { findMyAnalysisSessions } from '../api/list';
+import { AppError } from '@/07-shared/errors';
+import type { AnalysisSessionListItem } from '../model/types';
+
+describe('findMyAnalysisSessions', () => {
+  const fetchMock = vi.fn();
+
+  const MOCK_SESSIONS: AnalysisSessionListItem[] = [
+    {
+      sessionId: 'session-1',
+      articleId: 'article-1',
+      articleTitle: '반도체 시장 전망',
+      articleUrl: 'https://news.example.com/semiconductor',
+      articleDomain: 'news.example.com',
+      status: 'COMPLETED',
+      totalScore: 78,
+      requestedAt: '2026-06-01T10:00:00Z',
+      completedAt: '2026-06-01T10:01:30Z',
+    },
+    {
+      sessionId: 'session-2',
+      articleId: null,
+      articleTitle: null,
+      articleUrl: null,
+      articleDomain: null,
+      status: 'PENDING',
+      totalScore: null,
+      requestedAt: '2026-06-01T11:00:00Z',
+      completedAt: null,
+    },
+  ];
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('200 응답 시 AnalysisSessionListItem 배열을 파싱해 반환한다', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify(MOCK_SESSIONS), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const result = await findMyAnalysisSessions('valid-token');
+
+    expect(result).toHaveLength(2);
+    expect(result[0]?.sessionId).toBe('session-1');
+    expect(result[0]?.status).toBe('COMPLETED');
+    expect(result[1]?.totalScore).toBeNull();
+  });
+
+  it('Authorization: Bearer 헤더를 올바르게 전달한다', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    await findMyAnalysisSessions('my-access-token');
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const headers = new Headers(init.headers);
+    expect(headers.get('Authorization')).toBe('Bearer my-access-token');
+  });
+
+  it('401 응답 시 AppError(401)를 throw한다 (CX-8 — page에서 /login 리다이렉트)', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: 'fail',
+          statusCode: 401,
+          message: '인증이 필요합니다',
+        }),
+        {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+    );
+
+    const error = await findMyAnalysisSessions('expired-token').catch(
+      (e: unknown) => e
+    );
+
+    expect(error).toBeInstanceOf(AppError);
+    expect((error as AppError).statusCode).toBe(401);
+  });
+
+  it('빈 배열을 정상 파싱한다 (이력 0건)', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const result = await findMyAnalysisSessions('valid-token');
+    expect(result).toEqual([]);
+  });
+});

--- a/src/06-entities/analysis-session/api/list.ts
+++ b/src/06-entities/analysis-session/api/list.ts
@@ -1,0 +1,18 @@
+// api/base 직접 import — @/07-shared/api barrel은 next/headers(server-only) 재export라
+// Edge/browser 번들 오염 위험. 기존 backend.ts 패턴 정합.
+import { apiClient } from '@/07-shared/api/base';
+import type { AnalysisSessionListItem } from '@/06-entities/analysis-session/model/types';
+
+/**
+ * GET /api/v1/analysis-sessions — 인증 사용자 분석 이력 목록.
+ * Server Component(app/history/page.tsx)에서 호출하며, accessToken은 호출자가 주입한다.
+ * 401 시 apiClient가 AppError(401)로 변환 — page에서 catch해 /login 리다이렉트(CX-8).
+ */
+export async function findMyAnalysisSessions(
+  accessToken: string
+): Promise<AnalysisSessionListItem[]> {
+  return apiClient.get<AnalysisSessionListItem[]>('/analysis-sessions', {
+    headers: { Authorization: `Bearer ${accessToken}` },
+    cache: 'no-store',
+  });
+}

--- a/src/06-entities/analysis-session/index.ts
+++ b/src/06-entities/analysis-session/index.ts
@@ -1,0 +1,5 @@
+export type {
+  AnalysisSessionListItem,
+  AnalysisSessionStatus,
+} from './model/types';
+export { findMyAnalysisSessions } from './api/list';

--- a/src/06-entities/analysis-session/model/types.ts
+++ b/src/06-entities/analysis-session/model/types.ts
@@ -1,0 +1,20 @@
+// FSD 슬라이스 독립성: article 슬라이스의 동명 타입을 import하지 않고 자체 정의(cross-slice 금지).
+// fsd/no-cross-slice-dependency ESLint 룰 준수(CX-2).
+export type AnalysisSessionStatus =
+  | 'PENDING'
+  | 'EXTRACTING'
+  | 'ANALYZING'
+  | 'COMPLETED'
+  | 'FAILED';
+
+export interface AnalysisSessionListItem {
+  sessionId: string;
+  articleId: string | null;
+  articleTitle: string | null;
+  articleUrl: string | null;
+  articleDomain: string | null;
+  status: AnalysisSessionStatus;
+  totalScore: number | null; // null = 검증 가능 주장 없음 (ADR-019)
+  requestedAt: string; // ISO
+  completedAt: string | null; // ISO
+}

--- a/src/06-entities/article/api/__tests__/backend.test.ts
+++ b/src/06-entities/article/api/__tests__/backend.test.ts
@@ -2,12 +2,32 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { requestArticleExtraction } from '../backend';
 import { AppError } from '@/07-shared/errors';
 
+// Phase 70: getSupabaseBrowserClient mock — getSession 반환값을 케이스별로 제어.
+vi.mock('@/07-shared/api/supabase/client', () => ({
+  getSupabaseBrowserClient: vi.fn(),
+}));
+
+import { getSupabaseBrowserClient } from '@/07-shared/api/supabase/client';
+
 /**
  * #45 키리스 Edge 프록시 — requestArticleExtraction이 same-origin 프록시 경로를
  * 경유하는지(T5), BE 4xx 메시지가 프록시 패스스루를 거쳐 AppError까지 보존되는지(T5-b) 검증.
+ * Phase 70 추가: 로그인 시 Authorization 헤더 첨부(T5-c), 미로그인 시 미첨부(T5-d) 검증.
  */
 describe('requestArticleExtraction (#45 키리스 Edge 프록시)', () => {
   const fetchMock = vi.fn();
+
+  function mockSupabaseSession(token: string | null) {
+    (getSupabaseBrowserClient as ReturnType<typeof vi.fn>).mockReturnValue({
+      auth: {
+        getSession: vi.fn().mockResolvedValue({
+          data: {
+            session: token ? { access_token: token } : null,
+          },
+        }),
+      },
+    });
+  }
 
   beforeEach(() => {
     vi.stubGlobal('fetch', fetchMock);
@@ -19,6 +39,7 @@ describe('requestArticleExtraction (#45 키리스 Edge 프록시)', () => {
   });
 
   it('T5: same-origin 프록시 경로(/api/proxy/analysis-sessions)로 호출하고 BE 응답을 Article로 합성한다', async () => {
+    mockSupabaseSession(null);
     fetchMock.mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -44,6 +65,7 @@ describe('requestArticleExtraction (#45 키리스 Edge 프록시)', () => {
   });
 
   it('T5-b: 프록시가 패스스루한 BE 4xx 메시지가 AppError까지 보존된다 (Round 2 C2-1)', async () => {
+    mockSupabaseSession(null);
     fetchMock.mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -63,5 +85,47 @@ describe('requestArticleExtraction (#45 키리스 Edge 프록시)', () => {
       '분석 대상 URL에 접근할 수 없습니다'
     );
     expect((error as AppError).statusCode).toBe(422);
+  });
+
+  it('T5-c: 로그인 상태에서 Authorization Bearer 헤더를 프록시로 전달한다 (Phase 70)', async () => {
+    mockSupabaseSession('test-access-token-123');
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          sessionId: 's-2',
+          status: 'EXTRACTING',
+          articleId: 'a-2',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+
+    await requestArticleExtraction('https://news.example.com/b');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const headers = new Headers(init.headers);
+    expect(headers.get('Authorization')).toBe('Bearer test-access-token-123');
+  });
+
+  it('T5-d: 미로그인 상태에서 Authorization 헤더를 전달하지 않는다 (Phase 70)', async () => {
+    mockSupabaseSession(null);
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          sessionId: 's-3',
+          status: 'EXTRACTING',
+          articleId: 'a-3',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+
+    await requestArticleExtraction('https://news.example.com/c');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const headers = new Headers(init.headers);
+    expect(headers.has('Authorization')).toBe(false);
   });
 });

--- a/src/06-entities/article/api/backend.ts
+++ b/src/06-entities/article/api/backend.ts
@@ -3,6 +3,7 @@
 // barrel 경유 시 client component bundle에 server-only code 폴루션 (next build 실패).
 // 기존 TruthScope 패턴 정합 — 05-features/analysis/api.ts:1 와 동일.
 import { apiClient } from '@/07-shared/api/base';
+import { getSupabaseBrowserClient } from '@/07-shared/api/supabase/client';
 import {
   fromAnalysisSession,
   fromBackendDto,
@@ -24,10 +25,21 @@ import type { Article } from '@06-entities/article/model/article';
  * 패스스루하므로 ArticleExtractionResponse 매핑은 영향받지 않는다.
  */
 export async function requestArticleExtraction(url: string): Promise<Article> {
+  // 로그인 사용자의 액세스 토큰을 첨부해 BE가 member_id를 바인딩할 수 있게 한다(Phase 70 / ADR-027).
+  // 미로그인(session null)이면 헤더를 첨부하지 않아 BE 익명 분석 흐름을 유지한다.
+  const { data } = await getSupabaseBrowserClient().auth.getSession();
+  const token = data.session?.access_token;
   const response = await apiClient.post<
     ArticleExtractionResponse,
     ArticleExtractionRequest
-  >('/api/proxy/analysis-sessions', { url }, { baseUrl: '' });
+  >(
+    '/api/proxy/analysis-sessions',
+    { url },
+    {
+      baseUrl: '',
+      headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+    }
+  );
   return fromAnalysisSession(url, response);
 }
 

--- a/src/app/api/proxy/analysis-sessions/__tests__/route.test.ts
+++ b/src/app/api/proxy/analysis-sessions/__tests__/route.test.ts
@@ -190,4 +190,32 @@ describe('POST /api/proxy/analysis-sessions (#45 키리스 Edge 프록시)', () 
     expect(res.status).toBe(201);
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
+
+  it('T4-12: Authorization 헤더가 있으면 BE로 전달한다 (Phase 70 / ADR-027)', async () => {
+    const req = new Request('http://localhost/api/proxy/analysis-sessions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer test-supabase-token',
+      },
+      body: JSON.stringify({ url: 'https://news.example.com/a' }),
+    });
+
+    await POST(req);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const headers = new Headers(init.headers);
+    expect(headers.get('Authorization')).toBe('Bearer test-supabase-token');
+    // X-User-Gemini-Key는 여전히 미전달(키리스 정책 유지)
+    expect(headers.has('X-User-Gemini-Key')).toBe(false);
+  });
+
+  it('T4-13: Authorization 헤더가 없으면 BE로 전달하지 않는다 (익명 분석 유지)', async () => {
+    await POST(makeRequest({ url: 'https://news.example.com/a' }));
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const headers = new Headers(init.headers);
+    expect(headers.has('Authorization')).toBe(false);
+  });
 });

--- a/src/app/api/proxy/analysis-sessions/route.ts
+++ b/src/app/api/proxy/analysis-sessions/route.ts
@@ -34,18 +34,26 @@ export async function POST(request: Request): Promise<Response> {
 
   const payload = JSON.stringify(body);
 
+  // 로그인 사용자의 Supabase 액세스 토큰 — BE member 바인딩용 (ADR-027).
+  // X-User-Gemini-Key는 여전히 전달하지 않는다(키리스 정책 유지).
+  const authHeader = request.headers.get('Authorization');
+
   // 자동 재시도 루프. 재시도 대상은 일시적 실패(BE 5xx, 일시 네트워크 오류)뿐이다.
   // 4xx(요청 오류)는 결정적이라 즉시 패스스루하고, 타임아웃은 이미 15초를 기다렸으므로
   // 재시도하지 않고 504로 끊는다(누적 대기 폭증 방지).
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     let beRes: Response;
     try {
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      };
+      if (authHeader) {
+        headers.Authorization = authHeader;
+      }
       beRes = await fetch(`${config.api.baseUrl}/analysis-sessions`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Accept: 'application/json',
-        },
+        headers,
         body: payload,
         signal: AbortSignal.timeout(15000),
       });

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -1,9 +1,13 @@
 import { redirect } from 'next/navigation';
 import { HistoryPage } from '@/03-pages';
 import { getSupabaseServerClient } from '@/07-shared/api/supabase/server';
+import { findMyAnalysisSessions } from '@/06-entities/analysis-session';
+import { AppError } from '@/07-shared/errors';
 
 export default async function History() {
   const supabase = await getSupabaseServerClient();
+
+  // 보안: getUser()로 네트워크 검증 후, getSession()으로 액세스 토큰 취득(@supabase/ssr 권고).
   const {
     data: { user },
   } = await supabase.auth.getUser();
@@ -12,5 +16,26 @@ export default async function History() {
     redirect('/login?next=/history');
   }
 
-  return <HistoryPage />;
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session?.access_token) {
+    redirect('/login?next=/history');
+  }
+
+  let sessions;
+  try {
+    sessions = await findMyAnalysisSessions(session.access_token);
+  } catch (e) {
+    // 토큰 stale/만료 시 401 AppError → /login 리다이렉트(CX-8/H-2).
+    // redirect()는 내부적으로 throw하므로 try 안에서 쓰지 않는다.
+    if (e instanceof AppError && e.statusCode === 401) {
+      redirect('/login?next=/history');
+    }
+    // 그 외 에러(5xx 등)는 error.tsx 경계로 전파.
+    throw e;
+  }
+
+  return <HistoryPage sessions={sessions} />;
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -84,6 +84,7 @@ export default defineConfig({
           name: 'browser',
           setupFiles: ['./vitest.setup.browser.ts'],
           include: [
+            'src/03-pages/**/__tests__/**/*.test.tsx',
             'src/04-widgets/**/*.test.tsx',
             'src/05-features/**/ui/**/*.test.tsx',
           ],


### PR DESCRIPTION
<!-- SAFE_OP_START -->
Assumptions: BE feat/70-history-real-data-backend(또는 dev 머지본)가 `GET /api/v1/analysis-sessions`를 제공해야 실데이터가 표시됨(이 PR은 BE mock으로 단위 검증). 없는 신규 의존성 0.
Scope: src/app/api/proxy/analysis-sessions/route.ts(+test), src/06-entities/article/api/backend.ts(+test), src/06-entities/analysis-session/**(신규 슬라이스: model/types.ts, api/list.ts, index.ts, __tests__), src/app/history/page.tsx, src/03-pages/history/history-page.tsx(+__tests__), vitest.config.ts(browser project include 추가).
Out-of-scope: 이력 검색/필터/정렬/페이지네이션 실동작(스코프 밖), 익명→로그인 병합, 전역 신뢰도 통계 섹션(가짜 데이터라 제거). 로컬 작업 트리의 CRLF phantom diff(Phase 70 무관, 미커밋).
<!-- SAFE_OP_END -->

## Done

- [✅] **요구사항 목록**: (입력) 로그인 사용자가 `/history` 진입. (출력) 자신의 실제 분석 세션 목록(제목/도메인/날짜/점수/상태)을 카드로 표시, 이력 0건이면 빈 상태. (에러) 토큰 401 시 `/login?next=/history` 리다이렉트. (경계) 익명 분석 흐름 보존(미로그인 분석은 토큰 미첨부).
- [✅] **산출물 목록**: Edge 프록시 Authorization 전달(키리스 정책 유지), requestArticleExtraction의 Supabase 토큰 첨부, 06-entities/analysis-session 슬라이스(타입+apiClient.get 서버 fetch), history/page.tsx 서버 fetch+401 가드, HistoryPage 실데이터+빈 상태+디자인 토큰(MD3 무효 클래스 제거, ADR-019 라벨).
- [✅] **수용 테스트**: route.test T4-12/T4-13(Authorization 전달/미전달), backend.test(세션 있음/없음 토큰 첨부, getSupabaseBrowserClient mock), list.test(200 파싱/401 AppError), history-page.test(빈 상태/목록/totalScore null). 회귀 시뮬레이션 A(프록시 헤더)+B(토큰 읽기)+C(빈/목록 분기) fail→pass 실측 박제(`.plans/70-history-real-data/regression-sim/fe-*.log`).

## Behavior Gates 자체 점검

- [✅] Gate 1 — Goal Defined
- [✅] Gate 2 — Assumption Surfaced
- [✅] Gate 3 — Surgical Diff (커밋별 git show --stat로 Phase 70 파일만 포함 확인, CRLF phantom 파일 미포함)
- [✅] Gate 4 — Minimum Code

---

## 관련 Issue
Phase 70 (history-real-data). 단일 GitHub 이슈 없음 — `.plans/70-history-real-data/PLAN.md` 기준.

## 변경 사항
- 분석 POST: 로그인 시 브라우저 세션 access token을 `Authorization: Bearer`로 첨부 → Edge 프록시가 BE로 전달(ADR-027). X-User-Gemini-Key는 여전히 미전달(ADR-025 키리스 유지).
- 이력 GET: `/history` Server Component가 getUser() 가드 후 getSession() 토큰으로 BE `GET /api/v1/analysis-sessions` 직접 fetch(apiClient.get), 401이면 /login 리다이렉트.
- 신규 06-entities/analysis-session 슬라이스(타입 자체 정의 — cross-slice import 회피).
- HistoryPage 하드코딩 stub 제거 → props 실데이터 + 빈 상태 + var(--color-*) 토큰. 점수 라벨 "검증 가능 주장 기준 종합 점수", null이면 "검증 가능 주장 없음"(ADR-019).

## 검증
- [✅] typecheck / lint / arch(dep-cruiser) / check:names / check:cache PASS
- [✅] test:unit 191 + test:browser 43 PASS
- [✅] `npm run build` 성공(/history Dynamic SSR)
- [✅] 회귀 시뮬레이션 A·B·C fail→pass stdout 박제
- [ ] 라이브 분석→/history 실데이터 표시(BE 배포 후 E2E)

## 스크린샷 (UI 변경 시)
배포 후 canonical 도메인에서 캡처 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
