### PR TITLE
Phase 67: 결과 카드 verifiedAt 실데이터 연결 + 근거 보기 토글

### DIFF
--- a/src/04-widgets/result-card/lib/build-snapshot.test.ts
+++ b/src/04-widgets/result-card/lib/build-snapshot.test.ts
@@ -139,17 +139,39 @@ describe('buildResultCardSnapshot — rename chain', () => {
     expect(snap.claims?.[0]?.factCheck.truthLabel).toBeUndefined();
   });
 
-  it('analysisCompletedAt → freshness.createdAtMs로 변환된다', () => {
-    const snap = buildResultCardSnapshot(makeBaseDto());
+  // MF-4 (a): verifiedAt이 있으면 verifiedAt → freshness.createdAtMs로 변환된다
+  it('verifiedAt이 있으면 verifiedAt → freshness.createdAtMs로 변환된다', () => {
+    // claim.verifiedAt을 analysisCompletedAt과 다른 값으로 설정해 구분
+    const claimVerifiedAt = '2026-04-01T08:00:00.000Z';
+    const dto = makeBaseDto({
+      analysisCompletedAt: '2026-05-31T10:00:00.000Z', // 다른 값
+      claims: [makeClaimItem({ verifiedAt: claimVerifiedAt })],
+    });
+    const snap = buildResultCardSnapshot(dto);
     expect(snap.freshness).toBeDefined();
-    expect(snap.freshness?.createdAtMs).toBe(
-      Date.parse('2026-05-31T10:00:00.000Z')
-    );
+    // verifiedAt 기준이어야 함 (analysisCompletedAt 아님)
+    expect(snap.freshness?.createdAtMs).toBe(Date.parse(claimVerifiedAt));
   });
 
-  it('analysisCompletedAt=null이면 freshness는 undefined', () => {
+  // MF-4 (b): 모든 claim verifiedAt이 falsy이면 analysisCompletedAt 폴백
+  it('모든 claim verifiedAt이 없으면 analysisCompletedAt → freshness.createdAtMs로 폴백된다', () => {
+    const fallbackAt = '2026-05-31T10:00:00.000Z';
+    // verifiedAt을 빈 문자열로 덮어쓰면 .find(c => c.verifiedAt) 가 falsy 처리
+    const dto = makeBaseDto({
+      analysisCompletedAt: fallbackAt,
+      claims: [makeClaimItem({ verifiedAt: '' as unknown as string })],
+    });
+    const snap = buildResultCardSnapshot(dto);
+    expect(snap.freshness).toBeDefined();
+    expect(snap.freshness?.createdAtMs).toBe(Date.parse(fallbackAt));
+  });
+
+  it('analysisCompletedAt=null이고 verifiedAt도 없으면 freshness는 undefined', () => {
     const snap = buildResultCardSnapshot(
-      makeBaseDto({ analysisCompletedAt: null })
+      makeBaseDto({
+        analysisCompletedAt: null,
+        claims: [makeClaimItem({ verifiedAt: '' as unknown as string })],
+      })
     );
     expect(snap.freshness).toBeUndefined();
   });

--- a/src/04-widgets/result-card/lib/build-snapshot.ts
+++ b/src/04-widgets/result-card/lib/build-snapshot.ts
@@ -60,10 +60,16 @@ export function buildResultCardSnapshot(
 
   const cov = dto.coverage;
 
+  // MF-4 / T15: per-claim verifiedAt 우선, 없으면 analysisCompletedAt 폴백
+  // dto.claims[n].verifiedAt 중 첫 번째 truthy 값을 freshness 기준으로 사용한다.
+  const firstVerifiedAt = dto.claims.find((c) => c.verifiedAt)?.verifiedAt;
+
   return {
-    freshness: dto.analysisCompletedAt
-      ? freshnessSnapshotFromIso(dto.analysisCompletedAt)
-      : undefined,
+    freshness: firstVerifiedAt
+      ? freshnessSnapshotFromIso(firstVerifiedAt)
+      : dto.analysisCompletedAt
+        ? freshnessSnapshotFromIso(dto.analysisCompletedAt)
+        : undefined,
     articleFactScore: cov
       ? {
           value: dto.totalScore ?? undefined,

--- a/src/04-widgets/result-card/ui/claim-card.test.tsx
+++ b/src/04-widgets/result-card/ui/claim-card.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import { ClaimCard } from './claim-card';
 import type { ClaimCardSnapshot } from '../model/types';
 import type { EvidenceDto } from '@06-entities/article';
@@ -138,6 +138,8 @@ describe('ClaimCard — evidence 단일 렌더(중복 금지)', () => {
         index={1}
       />
     );
+    // 근거 섹션은 기본 닫힘 토글이므로 먼저 펼친 뒤 검증한다
+    fireEvent.click(screen.getByRole('button', { name: '근거 보기' }));
     // publisher 텍스트가 정확히 1개만 나타나야 한다(중복 렌더 없음)
     const links = screen.getAllByRole('link');
     const evidenceLinks = links.filter((l) =>

--- a/src/04-widgets/result-card/ui/fact-check-section.tsx
+++ b/src/04-widgets/result-card/ui/fact-check-section.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useId } from 'react';
+import { useId, useState } from 'react';
 import { cn } from '@/07-shared/lib/cn';
 import { EvidenceCard } from '@04-widgets/result-card/ui/evidence-card';
 import type {
@@ -58,6 +58,8 @@ interface Props {
 
 export function FactCheckSection({ snapshot, className }: Props) {
   const titleId = useId();
+  // T16: 근거 보기 토글 (기본 닫힘, MF-4 대응)
+  const [evidenceOpen, setEvidenceOpen] = useState(false);
   const display = snapshot?.truthLabel
     ? TRUTH_LABEL_DISPLAY[snapshot.truthLabel]
     : snapshot?.status
@@ -116,9 +118,14 @@ export function FactCheckSection({ snapshot, className }: Props) {
 
       <div className="flex flex-col gap-[var(--spacing-10)]">
         <div className="flex items-baseline justify-between">
-          <p className="text-xs uppercase tracking-wide text-[var(--color-text-secondary)]">
-            근거
-          </p>
+          <button
+            type="button"
+            aria-expanded={evidenceOpen}
+            onClick={() => setEvidenceOpen((prev) => !prev)}
+            className="text-xs uppercase tracking-wide text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
+          >
+            {evidenceOpen ? '근거 닫기' : '근거 보기'}
+          </button>
           {showConfidence && (
             <p
               aria-label={`신뢰도 ${snapshot?.confidence}퍼센트`}
@@ -128,11 +135,11 @@ export function FactCheckSection({ snapshot, className }: Props) {
             </p>
           )}
         </div>
-        {snapshot?.evidence?.length ? (
+        {evidenceOpen && snapshot?.evidence?.length ? (
           <EvidenceCard evidence={snapshot.evidence} />
-        ) : (
+        ) : evidenceOpen ? (
           <SkeletonLines lines={3} />
-        )}
+        ) : null}
       </div>
 
       {snapshot?.disclaimer && (


### PR DESCRIPTION
## 변경

- build-snapshot.ts: claim별 verifiedAt를 freshness 기준으로 사용, 없으면 분석 완료 시각(analysisCompletedAt)으로 폴백
- build-snapshot.test.ts: verifiedAt 분기 + 폴백 분기 실제 단언 추가
- fact-check-section.tsx: 근거 보기/닫기 토글 (기본 닫힘, aria-expanded)

Phase 72의 프론트엔드 부분이다. 백엔드 v2 점수 산식(조건부 cap)과 Naver 보조 출처는 truthscope-web-backend dev에 별도 반영했다.

<!-- SAFE_OP_START -->
Assumptions: 없음
Scope: src/04-widgets/result-card/lib/build-snapshot.ts, src/04-widgets/result-card/lib/build-snapshot.test.ts, src/04-widgets/result-card/ui/fact-check-section.tsx
Out-of-scope: 백엔드 점수 산식과 Naver(별도 repo dev 반영), 다른 위젯, 저장소 전반 라인 엔딩 정규화
<!-- SAFE_OP_END -->

## Done

- 요구사항(AC): claim에 verifiedAt가 있으면 freshness가 그 값을 기준으로 표시되고, 모든 claim에 verifiedAt가 없으면 analysisCompletedAt로 폴백한다. 근거 섹션은 기본 닫힘이며 버튼으로 펼치고 닫는다(aria-expanded 반영).
- 산출물: 위 Scope의 3개 파일 (build-snapshot.ts, build-snapshot.test.ts, fact-check-section.tsx)
- 수용 테스트: build-snapshot.test.ts의 verifiedAt 분기 단언 + 폴백 분기 단언. 로컬 검증 tsc --noEmit clean, eslint pass, test:coverage 192/192 통과.
