### PR TITLE
💄 style(result-card): 판정 라벨 색 통합 + 커버리지 배지 + 근거 버튼 강조

### DIFF
--- a/src/04-widgets/article-fact-score/model/types.ts
+++ b/src/04-widgets/article-fact-score/model/types.ts
@@ -12,6 +12,6 @@ export interface ArticleFactScoreSnapshot {
   value?: number;
   /** 검증 가능 claim 수 (CoverageSummary.scorableCount). */
   scorableCount?: number;
-  /** 전체 claim 수 (scorableCount + excludedCount). coverage "N개 중 M개 기준" 텍스트 생성용. */
+  /** 전체 claim 수 (scorableCount + excludedCount). 커버리지 배지 "검증된 주장 N/M개" + 초과분 "K개는 검증 불가" 생성용. */
   totalClaimCount?: number;
 }

--- a/src/04-widgets/article-fact-score/ui/article-fact-score.tsx
+++ b/src/04-widgets/article-fact-score/ui/article-fact-score.tsx
@@ -24,6 +24,9 @@ export function ArticleFactScore({ snapshot, className }: Props) {
   const hasCoverage =
     typeof snapshot.scorableCount === 'number' &&
     typeof snapshot.totalClaimCount === 'number';
+  const coverageTotal = snapshot.totalClaimCount ?? 0;
+  const coverageScorable = snapshot.scorableCount ?? 0;
+  const coverageExcluded = coverageTotal - coverageScorable;
 
   return (
     <section
@@ -45,15 +48,27 @@ export function ArticleFactScore({ snapshot, className }: Props) {
           <span className="text-xs text-[var(--color-text-secondary)]">
             {SCORE_LABEL}
           </span>
-          {hasCoverage && (
-            <span
-              aria-label={`검증 가능 주장 ${snapshot.totalClaimCount}개 중 ${snapshot.scorableCount}개 기준`}
-              className="text-xs text-[var(--color-text-secondary)] tabular-nums"
-            >
-              검증 가능 {snapshot.totalClaimCount}개 중 {snapshot.scorableCount}
-              개 기준
-            </span>
-          )}
+          {hasCoverage &&
+            (coverageExcluded > 0 ? (
+              <span
+                role="note"
+                aria-label={`검증된 주장 ${coverageTotal}개 중 ${coverageScorable}개, ${coverageExcluded}개는 검증 불가`}
+                className="inline-flex items-center gap-[var(--spacing-6)] rounded-full border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface-sunken)] px-[var(--spacing-10)] py-[var(--spacing-6)] text-xs font-semibold text-[var(--color-text-primary)] tabular-nums"
+              >
+                <span
+                  aria-hidden="true"
+                  className="text-[var(--color-text-secondary)]"
+                >
+                  ⓘ
+                </span>
+                검증된 주장 {coverageScorable}/{coverageTotal}개 ·{' '}
+                {coverageExcluded}개는 검증 불가
+              </span>
+            ) : (
+              <span className="text-xs text-[var(--color-text-secondary)] tabular-nums">
+                검증된 주장 {coverageScorable}/{coverageTotal}개
+              </span>
+            ))}
         </>
       ) : (
         <>

--- a/src/04-widgets/result-card/ui/claim-card.test.tsx
+++ b/src/04-widgets/result-card/ui/claim-card.test.tsx
@@ -139,7 +139,7 @@ describe('ClaimCard — evidence 단일 렌더(중복 금지)', () => {
       />
     );
     // 근거 섹션은 기본 닫힘 토글이므로 먼저 펼친 뒤 검증한다
-    fireEvent.click(screen.getByRole('button', { name: '근거 보기' }));
+    fireEvent.click(screen.getByRole('button', { name: /근거 1건 보기/ }));
     // publisher 텍스트가 정확히 1개만 나타나야 한다(중복 렌더 없음)
     const links = screen.getAllByRole('link');
     const evidenceLinks = links.filter((l) =>

--- a/src/04-widgets/result-card/ui/fact-check-section.tsx
+++ b/src/04-widgets/result-card/ui/fact-check-section.tsx
@@ -18,7 +18,6 @@ interface VerdictDisplay {
     | 'mixed'
     | 'error-soft'
     | 'error'
-    | 'info'
     | 'neutral';
 }
 
@@ -32,7 +31,7 @@ const TRUTH_LABEL_DISPLAY: Record<TruthLabel, VerdictDisplay> = {
 
 const STATUS_DISPLAY: Record<ClaimScoreStatus, VerdictDisplay> = {
   INSUFFICIENT: { label: '근거 부족', icon: '?', tone: 'neutral' },
-  TIME_SENSITIVE: { label: '시점 의존', icon: '⋯', tone: 'info' },
+  TIME_SENSITIVE: { label: '시점 의존', icon: '⋯', tone: 'neutral' },
   OUT_OF_SCOPE: { label: '검증 범위 밖', icon: '—', tone: 'neutral' },
 };
 
@@ -41,12 +40,12 @@ const TONE_CLASS: Record<VerdictDisplay['tone'], string> = {
     'bg-[var(--color-success-subtle)] text-[var(--color-success-strong)] ring-[var(--color-success-strong)]/30',
   'success-soft':
     'bg-[var(--color-success-subtle)] text-[var(--color-success-strong)]/80 ring-[var(--color-success-strong)]/20',
-  mixed: 'bg-brand-subtle text-brand-primary ring-brand-primary/30',
+  mixed:
+    'bg-[var(--color-warning-subtle)] text-[var(--color-warning-strong)] ring-[var(--color-warning-strong)]/30',
   'error-soft':
     'bg-[var(--color-error-subtle)] text-[var(--color-error)]/80 ring-[var(--color-error)]/20',
   error:
     'bg-[var(--color-error-subtle)] text-[var(--color-error)] ring-[var(--color-error)]/30',
-  info: 'bg-[var(--color-blue-50)] text-[var(--color-info)] ring-[var(--color-info)]/30',
   neutral:
     'bg-[var(--color-bg-surface-sunken)] text-[var(--color-text-secondary)] ring-[var(--color-border-subtle)]',
 };
@@ -60,6 +59,7 @@ export function FactCheckSection({ snapshot, className }: Props) {
   const titleId = useId();
   // T16: 근거 보기 토글 (기본 닫힘, MF-4 대응)
   const [evidenceOpen, setEvidenceOpen] = useState(false);
+  const evidenceCount = snapshot?.evidence?.length ?? 0;
   const display = snapshot?.truthLabel
     ? TRUTH_LABEL_DISPLAY[snapshot.truthLabel]
     : snapshot?.status
@@ -117,15 +117,28 @@ export function FactCheckSection({ snapshot, className }: Props) {
       </div>
 
       <div className="flex flex-col gap-[var(--spacing-10)]">
-        <div className="flex items-baseline justify-between">
-          <button
-            type="button"
-            aria-expanded={evidenceOpen}
-            onClick={() => setEvidenceOpen((prev) => !prev)}
-            className="text-xs uppercase tracking-wide text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
-          >
-            {evidenceOpen ? '근거 닫기' : '근거 보기'}
-          </button>
+        <div className="flex items-center justify-between gap-[var(--spacing-16)]">
+          {evidenceCount > 0 ? (
+            <button
+              type="button"
+              aria-expanded={evidenceOpen}
+              onClick={() => setEvidenceOpen((prev) => !prev)}
+              className="inline-flex min-h-[40px] items-center gap-[var(--spacing-6)] rounded-full border border-[var(--color-brand-secondary)] bg-[var(--color-bg-base)] px-[var(--spacing-16)] py-[var(--spacing-8)] text-sm font-semibold text-[var(--color-brand-secondary)] transition-colors hover:bg-[var(--color-bg-surface)]"
+            >
+              <span>근거 {evidenceCount}건 보기</span>
+              <span
+                aria-hidden="true"
+                className={cn(
+                  'text-xl leading-none transition-transform',
+                  evidenceOpen && 'rotate-180'
+                )}
+              >
+                ▾
+              </span>
+            </button>
+          ) : (
+            <span aria-hidden="true" />
+          )}
           {showConfidence && (
             <p
               aria-label={`신뢰도 ${snapshot?.confidence}퍼센트`}
@@ -135,10 +148,8 @@ export function FactCheckSection({ snapshot, className }: Props) {
             </p>
           )}
         </div>
-        {evidenceOpen && snapshot?.evidence?.length ? (
+        {evidenceCount > 0 && evidenceOpen && snapshot?.evidence?.length ? (
           <EvidenceCard evidence={snapshot.evidence} />
-        ) : evidenceOpen ? (
-          <SkeletonLines lines={3} />
         ) : null}
       </div>
 


### PR DESCRIPTION
<!-- SAFE_OP_START -->
Assumptions: 판정 라벨 의미색은 브랜드 강조색이 아니라 status 색(FE tone 체계 정합). --color-action-hero는 tokens.css 주석상 ResultCard 금지이므로 근거 버튼은 --color-brand-secondary(blue-700, WCAG 대비 통과) 사용. coverage scorableCount<=totalClaimCount 가정.
Scope: 04-widgets/result-card/ui/fact-check-section.tsx, 04-widgets/article-fact-score/ui/article-fact-score.tsx, 04-widgets/article-fact-score/model/types.ts(주석), 04-widgets/result-card/ui/claim-card.test.tsx
Out-of-scope: BE 응답/점수 로직, 다른 위젯, article-fact-score 점수 숫자 색(기존 action-hero 유지), 판정 배지 role="status"(기존), tokens.css
<!-- SAFE_OP_END -->

## Done

- **요구사항 목록** (입력 / 출력 / 경계):
  - 입력: ClaimCardSnapshot(truthLabel/status/evidence/confidence), ArticleFactScoreSnapshot(value/scorableCount/totalClaimCount)
  - 출력: 라벨 색이 사실-거짓 램프(녹-앰버-적) + 검증 불가 3종 회색 하나로 통일. "일부 사실"=앰버, "시점 의존"=회색. 근거 버튼="근거 N건 보기" 외곽선 + 캐럿. 점수 옆 커버리지 배지.
  - 경계: evidence 0건 claim은 근거 버튼 숨김(신뢰도는 유지). scorableCount==totalClaimCount면 "검증된 주장 N/M개"만, 미만이면 "· K개는 검증 불가" 배지.
- **산출물 목록**:
  - `fact-check-section.tsx`: TONE_CLASS mixed→warning(앰버), TIME_SENSITIVE tone→neutral, dead `info` tone 제거, 근거 버튼 외곽선(brand-secondary)+개수 레이블+큰 캐럿(rotate)+aria-expanded
  - `article-fact-score.tsx`: 커버리지 배지(neutral, ⓘ, role=note) — coverageExcluded>0 시 "검증된 주장 N/M개 · K개는 검증 불가"
  - `article-fact-score/model/types.ts`: 주석 갱신
  - `claim-card.test.tsx`: 근거 버튼명 `/근거 1건 보기/`
- **수용 테스트** (자동):
  - `npm run check:ci` 통과 (format:check + typecheck + lint + stylelint + arch + check:names + check:cache + test:unit 192건 + build)
  - `npm run test:browser` 43건 통과 (claim-card 근거 버튼 토글 포함)

## Behavior Gates 자체 점검

- [✅] Gate 1 — Goal Defined (위 Done)
- [✅] Gate 2 — Assumption Surfaced (SAFE_OP)
- [✅] Gate 3 — Surgical Diff (4파일, 라벨 색·커버리지·근거 버튼 외 변경 없음. 라인엔딩 churn 미커밋)
- [✅] Gate 4 — Minimum Code (기존 토큰만 사용, 신규 토큰·추상화 없음)

> 실행/검증은 F1.a-d로 위임. 본 점검은 PR-level 입력 계약만.

---

## 변경 사항

결과 카드 판정 라벨이 8색이라 알록달록하던 것을, 색채 인지(ColorBrewer/Tseng EuroVis 2024)·status 색 관례(IBM Carbon)·WCAG 1.4.1 근거로 정리했다. 사실-거짓은 녹-앰버-적 램프, "검증 불가" 3종(근거 부족·시점 의존·검증 범위 밖)은 회색 하나로 통일하고, 파랑은 클릭 요소 전용으로 남겼다. 근거 보기는 발견성(NNGroup accordion / Pirolli 2004 information scent) 근거로 "근거 N건 보기" 외곽선 버튼 + 큰 캐럿으로 강조했다. 점수 옆 커버리지 배지("검증된 주장 N/M개 · K개는 검증 불가")는 implied truth effect(Pennycook 2020) 완화를 위해 미검증 분량을 명시한다.

## 체크리스트
- [✅] 빌드 성공
- [✅] 관련 테스트 통과 (unit 192 + browser 43)
- [✅] 불필요한 console 출력 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 검증 불가능한 주장 수를 명시적으로 표시하는 인라인 배지 추가

* **Bug Fixes**
  * 근거가 없을 때 불필요한 로딩 상태 제거

* **Style**
  * 시간 민감도 관련 상태 표시 톤 조정
  * 혼합 검증 결과 표시 색상 개선

* **Tests**
  * 근거 보기 버튼 표시 텍스트 변경에 맞춰 테스트 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->